### PR TITLE
Stop removing duplicates with Set.{toList, fromList} when shrinking.

### DIFF
--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -166,8 +166,6 @@ instance IxTraversable MemStep where
 
 ------------------------------------------------------------------------
 
-deriving instance Eq   (MemStep resp ConstIntRef)
-
 instance ShowCmd MemStep where
   showCmd New           = "New"
   showCmd (Read  ref)   = "Read ("  ++ show ref ++ ")"
@@ -185,35 +183,6 @@ instance Show a => Show (Untyped' MemStep (ConstSym1 a)) where
     "Untyped' (Inc ("   ++ show ref ++ ")) "  ++ show miref
   show (Untyped' (Copy  ref)   miref) =
     "Untyped' (Copy ("   ++ show ref ++ ")) (" ++ show miref ++ ")"
-
-instance Eq (Untyped' MemStep ConstIntRef) where
-  Untyped' c1 _ == Untyped' c2 _ = Just c1 == cast c2
-
-instance Ord (Untyped' MemStep ConstIntRef) where
-  Untyped' c1 _ <= Untyped' c2 _ = Just c1 <= cast c2
-
-data RawMemStep refs
-  = NewR
-  | ReadR  (refs @@ '())
-  | WriteR (refs @@ '()) Int
-  | IncR   (refs @@ '())
-  | CopyR  (refs @@ '())
-
-deriving instance Eq  (RawMemStep ConstIntRef)
-deriving instance Ord (RawMemStep ConstIntRef)
-
-raw :: MemStep resp refs -> RawMemStep refs
-raw New           = NewR
-raw (Read  ref)   = ReadR  ref
-raw (Write ref i) = WriteR ref i
-raw (Inc   ref)   = IncR   ref
-raw (Copy  ref)   = CopyR  ref
-
-instance Ord (MemStep resp ConstIntRef) where
-  c1 <= c2 = raw c1 <= raw c2
-
-instance IxForallF Show p => Show (Model p) where
-  show (Model m) = show m \\ (iinstF @'() Proxy :: IxForallF Show p :- Show (p @@ '()))
 
 ------------------------------------------------------------------------
 
@@ -299,6 +268,11 @@ prop_sequentialShrink = shrinkPropertyHelper (prop_safety Bug) $ alphaEq returns
   , Untyped' (Read  (IntRef (Ref 0) (Pid 0))) ()
   ]
   . read . (!! 1) . lines
+
+deriving instance Eq  (MemStep resp ConstIntRef)
+
+instance Eq (Untyped' MemStep ConstIntRef) where
+  Untyped' c1 _ == Untyped' c2 _ = Just c1 == cast c2
 
 cheat :: Fork [Untyped' MemStep (ConstSym1 refs)] -> Fork [Untyped' MemStep (ConstSym1 refs)]
 cheat = fmap (map (\ms -> case ms of

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -91,7 +91,6 @@ parallelProperty
   :: IxTraversable cmd
   => ShowCmd cmd
   => Show (IntRefed cmd)
-  => Ord (IntRefed cmd)
   => Ord       ix
   => SDecide   ix
   => SingKind  ix

--- a/src/Test/StateMachine/Internal/Parallel.hs
+++ b/src/Test/StateMachine/Internal/Parallel.hs
@@ -32,7 +32,6 @@ import           Data.Dynamic                          (Dynamic, fromDynamic,
                                                         toDyn)
 import           Data.List                             (partition)
 import qualified Data.Map                              as M
-import qualified Data.Set                              as S
 import           Data.Singletons.Decide                (SDecide)
 import           Data.Singletons.Prelude               (DemoteRep, SingKind,
                                                         fromSing)
@@ -82,11 +81,10 @@ liftGenFork gens returns = do
 liftShrinkFork
   :: forall ix cmd
   .  IxFoldable cmd
-  => Ord (IntRefed cmd)
   => (forall resp refs. cmd resp refs -> SResponse ix resp)
   -> Shrinker (IntRefed cmd)
   -> Shrinker (Fork [IntRefed cmd])
-liftShrinkFork returns shrinker f@(Fork l0 p0 r0) = S.toList $ S.fromList $
+liftShrinkFork returns shrinker f@(Fork l0 p0 r0) =
 
   -- Only shrink the branches:
   [ Fork l' p0 r'


### PR DESCRIPTION
Limited benchmarks seems to suggest this actually makes things faster,
but more importantly we don't need some annoying Eq and Ord instances!