### PR TITLE
Use `Void` rather than `()` in examples without references.

### DIFF
--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -29,6 +29,8 @@ import           Control.Monad.Identity
                    (Identity, runIdentity)
 import           Data.Singletons.Prelude
                    (ConstSym1)
+import           Data.Void
+                   (Void)
 import           Test.QuickCheck
                    (Gen, Property, elements, property)
 
@@ -42,7 +44,7 @@ import           Test.StateMachine
 -- We start of defining the different actions (or commands) that are
 -- allowed:
 
-data Step :: Signature () where
+data Step :: Signature Void where
   FillBig      :: Step refs ('Response ())  -- Fill the 5-liter jug.
   FillSmall    :: Step refs ('Response ())  -- Fill the 3-liter jug.
   EmptyBig     :: Step refs ('Response ())  -- Empty the 5-liter jug.
@@ -110,7 +112,7 @@ smm = StateMachineModel preconditions postconditions transitions initState
 -- The generator of actions is simple, with equal distribution pick an
 -- action.
 
-gen :: Gen (Untyped Step (RefPlaceholder ()))
+gen :: Gen (Untyped Step (RefPlaceholder Void))
 gen = elements
   [ Untyped FillBig
   , Untyped FillSmall
@@ -130,7 +132,7 @@ shrink1 _ = []
 -- We are not modeling an actual program here, so there's no semantics
 -- for our actions. We are merely doing model-checking here.
 
-semStep :: Step (ConstSym1 ()) resp -> Identity (Response_ (ConstSym1 ()) resp)
+semStep :: Step (ConstSym1 Void) resp -> Identity (Response_ (ConstSym1 Void) resp)
 semStep FillBig      = return ()
 semStep FillSmall    = return ()
 semStep EmptyBig     = return ()

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -26,6 +26,8 @@ module TicketDispenser
 
 import           Control.Monad.State
                    (StateT, get, lift, modify)
+import           Data.Void
+                   (Void)
 import           Prelude                          hiding
                    (readFile)
 import           System.Directory
@@ -46,7 +48,7 @@ import           Test.StateMachine.Internal.Types
 
 -- The actions of the ticket dispenser are:
 
-data Action :: Signature () where
+data Action :: Signature Void where
   TakeTicket :: Action refs ('Response Int)
   Reset      :: Action refs ('Response ())
 
@@ -88,7 +90,7 @@ smm = StateMachineModel preconditions postconditions transitions initModel
 -- With stateful generation we ensure that the dispenser is reset before
 -- use.
 
-gen :: StateT Bool Gen (Untyped Action (RefPlaceholder ()))
+gen :: StateT Bool Gen (Untyped Action (RefPlaceholder Void))
 gen = do
   initialised <- get
   if not initialised

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -35,6 +35,8 @@ import           Data.IORef
                    (IORef, newIORef, readIORef, writeIORef)
 import           Data.Singletons.Prelude
                    (ConstSym1)
+import           Data.Void
+                   (Void)
 import           Test.QuickCheck
                    (Gen, Property, arbitrary, choose, frequency,
                    ioProperty, property, shrink)
@@ -110,7 +112,7 @@ instance Show a => Show (Element a) where
 
 type Var = Int
 
-data Action :: Signature () where
+data Action :: Signature Void where
   New   :: Int        -> Action refs ('Response (Element Int))
   Find  :: Var        -> Action refs ('Response (Element Int))
   Union :: Var -> Var -> Action refs ('Response (Element Int))
@@ -173,7 +175,7 @@ smm = StateMachineModel preconditions postconditions transitions initModel
 -- The generation of actions is parametrised by the number of @New@'s
 -- that have been generated.
 
-gen :: StateT Int Gen (Untyped Action (RefPlaceholder ()))
+gen :: StateT Int Gen (Untyped Action (RefPlaceholder Void))
 gen = do
   n <- get
   if n == 0

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans      #-}
+
 {-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -71,7 +73,9 @@ module Test.StateMachine.Types
   ) where
 
 import           Data.Constraint
+                   ((:-)(Sub), Constraint, Dict(Dict), (\\))
 import           Data.Constraint.Forall
+                   (Forall, inst)
 import           Data.Kind
                    (Type)
 import           Data.Proxy
@@ -79,9 +83,12 @@ import           Data.Proxy
 import           Data.Singletons.Prelude
                    (type (@@), Apply, ConstSym1, Sing, TyFun)
 import           Data.Singletons.TH
-                   (DemoteRep, SDecide, SingKind)
+                   (DemoteRep, SDecide, SingKind, fromSing, toSing,
+                   (%~))
 import           Data.Typeable
                    (Typeable)
+import           Data.Void
+                   (Void, absurd)
 import           Test.QuickCheck.Property
                    (Property, property)
 
@@ -254,3 +261,13 @@ type Ords refs = IxForallF Ord refs :- Ord (refs @@ '())
 
 -- | Same as the above.
 type Ords' refs i = IxForallF Ord refs :- Ord (refs @@ i)
+
+------------------------------------------------------------------------
+
+instance SingKind Void where
+  type DemoteRep Void = Void
+  fromSing x = absurd (fromSing x)
+  toSing   x = absurd x
+
+instance SDecide Void where
+  x %~ _ = absurd (fromSing x)


### PR DESCRIPTION
Fixes issue #55.