### PR TITLE
split out helper properties into more combinator style

### DIFF
--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -156,15 +156,8 @@ instance HTraversable Action where
 -- Finally we have all the pieces needed to get the sequential property!
 
 prop_dieHard :: Property
-prop_dieHard = sequentialProperty
-  gen
-  shrink1
-  preconditions
-  transitions
-  postconditions
-  initModel
-  semAction
-  runIdentity
+prop_dieHard = forAllProgram gen shrink1 preconditions transitions initModel $
+  runSequentialProgram preconditions transitions postconditions initModel semAction runIdentity
 
 -- If we run @quickCheck prop_dieHard@ we get:
 --

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -170,10 +170,11 @@ semantics prb (Inc   ref)   =
 -- RaceCondition)@ will!
 
 prop_references :: Problem -> Property
-prop_references prb = sequentialProperty generator shrink1 precondition
-  transition postcondition initModel (semantics prb) ioProperty
-
+prop_references prb = forAllProgram generator shrink1 precondition transition initModel $
+  runSequentialProgram precondition transition postcondition initModel (semantics prb) ioProperty
 
 prop_referencesParallel :: Problem -> Property
-prop_referencesParallel prb = parallelProperty generator shrink1 precondition
-  transition postcondition initModel (semantics prb)
+prop_referencesParallel prb =
+  forAllParallelProgram generator shrink1 precondition transition initModel $ \parallel ->
+    runParallelProgram (semantics prb) parallel $
+      checkParallelInvariant transition postcondition initModel parallel

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -202,12 +202,7 @@ instance Show a => Show (Untyped (Action a)) where
 ------------------------------------------------------------------------
 
 prop_unionFind :: Property
-prop_unionFind = sequentialProperty
-  gen
-  shrink1
-  preconditions
-  transitions
-  postconditions
-  (initModel :: Model Int v)
-  semantics
-  ioProperty
+prop_unionFind = forAllProgram gen shrink1 preconditions transitions model $
+  runSequentialProgram preconditions transitions postconditions model semantics ioProperty
+  where
+    model = initModel :: Model Int v

--- a/src/Test/StateMachine/Internal/Types.hs
+++ b/src/Test/StateMachine/Internal/Types.hs
@@ -23,6 +23,7 @@ module Test.StateMachine.Internal.Types
   , Fork(..)
   , Internal(..)
   , Program(..)
+  , ParallelProgram(..)
   ) where
 
 import           Data.List
@@ -56,7 +57,7 @@ data Internal (act :: (* -> *) -> * -> *) where
     act Symbolic resp -> Symbolic resp -> Internal act
 
 -- | A program as a list of internal actions.
-data Program act = Program { unProgram :: [Internal act] }
+newtype Program act = Program { unProgram :: [Internal act] }
 
 instance Monoid (Program act) where
   mempty                                = Program []
@@ -77,3 +78,9 @@ instance (Show (Untyped act), HFoldable act) => Show (Program act) where
       show (Untyped act) ++ " (" ++ show var ++ ")"
 
     bracket s = "[" ++ s ++ "]"
+
+-- | A parallel program as a fork of program
+newtype ParallelProgram act = ParallelProgram { unParallelProgram :: Fork (Program act)}
+
+instance (Show (Untyped act), HFoldable act) => Show (ParallelProgram act) where
+  show = show . unParallelProgram

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -28,6 +28,7 @@ module Test.StateMachine.Types
   , Transition
   , Postcondition
   , Semantics
+  , InitialModel
 
   -- * Untyped actions
   , Untyped(..)
@@ -82,6 +83,8 @@ type Postcondition model act = forall resp.
 -- | The type of the semantics of some actions.
 type Semantics act m = forall resp. act Concrete resp -> m resp
 
+-- | The initial model
+type InitialModel m = forall (v :: * -> *). m v
 ------------------------------------------------------------------------
 
 -- | Untyped actions pack up the response type using an existential type.


### PR DESCRIPTION
This change also exposes the types of `Fork` and `Program` but not its constructors, so at the moment one can only plug and play in a similar fashion as the property helpers anyway (unless one imports the `Internal`), but I think it is okay.

Maybe we should also expose `checkParallelInvariant`?