### PR TITLE
Refactor/forall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 #### ???
 
-  * The parallel-io library dependency was replaced by async;
-
   * Two examples of how to test CRUD web applications were added.
+
+  * New and more flexible combinators for building sequential and parallel
+    properties replaced the old clunky ones.
 
 #### 0.1.0
 

--- a/example/quickcheck-state-machine-example.cabal
+++ b/example/quickcheck-state-machine-example.cabal
@@ -33,6 +33,7 @@ library
                      , quickcheck-instances
                      , quickcheck-state-machine
                      , random
+                     , resourcet
                      , servant
                      , servant-client
                      , servant-server

--- a/example/quickcheck-state-machine-example.cabal
+++ b/example/quickcheck-state-machine-example.cabal
@@ -22,11 +22,13 @@ library
                      , directory
                      , filelock
                      , http-client
+                     , lifted-async
+                     , monad-control
                      , monad-logger
                      , mtl
                      , persistent
-                     , persistent-template
                      , persistent-sqlite
+                     , persistent-template
                      , QuickCheck
                      , quickcheck-instances
                      , quickcheck-state-machine

--- a/example/src/CrudWebserverDb.hs
+++ b/example/src/CrudWebserverDb.hs
@@ -242,7 +242,7 @@ transitions (Model m) (PostUser   user) key = Model (m ++ [(Reference key, user)
 transitions m         (GetUser    _)    _   = m
 transitions (Model m) (IncAgeUser key)  _   = case lookup key m of
   Nothing              -> Model m
-  Just (User user age) -> Model (updateL key (User user (age + 2)) m)
+  Just (User user age) -> Model (updateL key (User user (age + 1)) m)
   where
   updateL :: Eq a => a -> b -> [(a, b)] -> [(a, b)]
   updateL x y xys = (x, y) : filter ((/= x) . fst) xys

--- a/example/src/CrudWebserverDb.hs
+++ b/example/src/CrudWebserverDb.hs
@@ -90,8 +90,6 @@ import           Test.QuickCheck
                    (===))
 import           Test.QuickCheck.Instances
                    ()
-import           Test.QuickCheck.Monadic
-                   (run)
 
 import           Test.StateMachine
 

--- a/example/src/CrudWebserverDb.hs
+++ b/example/src/CrudWebserverDb.hs
@@ -43,8 +43,6 @@ import           Control.Concurrent
                    (threadDelay)
 import           Control.Concurrent.Async.Lifted
                    (Async, async, cancel)
-import           Control.Monad
-                   (replicateM_)
 import           Control.Monad.IO.Class
                    (liftIO)
 import           Control.Monad.Logger
@@ -344,19 +342,17 @@ prop_crudWebserverDb :: Property
 prop_crudWebserverDb =
   bracketP (setup "sqlite.db" port) cancel $ \_ ->
     monadicSequential (sm port) $ \prog -> do
-      (hist, model, prop) <- runCommands (sm port) prog
-      prettyCommands prog hist model $
-        checkCommandNames prog 4 prop
+      (hist, model, prop) <- runProgram (sm port) prog
+      prettyProgram prog hist model $
+        checkActionNames prog 4 prop
   where
   port = 8081
 
 prop_crudWebserverDbParallel :: Property
 prop_crudWebserverDbParallel =
   bracketP (setup "sqlite-parallel.db" port) cancel $ \_ ->
-    monadicParallel (sm port) $ \prog -> do
-      replicateM_ 10 $ do
-        (hist, prop) <- runParallelCommands (sm port) prog
-        prettyParallelCommands prog hist prop
+    monadicParallel (sm port) $ \prog ->
+      prettyParallelProgram prog =<< runParallelProgram (sm port) prog
   where
   port = 8082
 

--- a/example/src/CrudWebserverFile.hs
+++ b/example/src/CrudWebserverFile.hs
@@ -245,12 +245,12 @@ prop_crudWebserverFile :: Property
 prop_crudWebserverFile =
   bracketP setup cancel $ \_ ->
     monadicSequential sm $ \prog -> do
-      (hist, model, prop) <- runCommands sm prog
-      prettyCommands prog hist model $
-        checkCommandNames prog 3 prop
+      (hist, model, prop) <- runProgram sm prog
+      prettyProgram prog hist model $
+        checkActionNames prog 3 prop
 
 prop_crudWebserverFileParallel :: Property
 prop_crudWebserverFileParallel =
   bracketP setup cancel $ \_ ->
     monadicParallel sm $ \prog ->
-      prettyParallelCommands' prog =<< runParallelCommands' sm prog
+      prettyParallelProgram prog =<< runParallelProgram sm prog

--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -156,17 +156,16 @@ instance HTraversable Action where
 -- To make the code fit on a line, we first group all things related to
 -- generation and execution of programs respectively.
 
-gen :: Generation Model Action IO
-gen = Generation generator shrinker preconditions transitions initModel id
-
-exec :: Execution Model Action IO
-exec = Execution preconditions transitions postconditions initModel semantics
+sm :: StateMachine Model Action IO
+sm = StateMachine
+  generator shrinker preconditions transitions
+  postconditions initModel semantics id
 
 prop_dieHard :: Property
-prop_dieHard = monadicSequential' gen $ \prog -> do
-  (hist, model, prop) <- runProgram exec prog
-  prettyCommands prog hist model $
-    checkCommandNames prog 4 prop
+prop_dieHard = monadicSequential sm $ \prog -> do
+  (hist, model, prop) <- runProgram sm prog
+  prettyProgram prog hist model $
+    checkActionNames prog 4 prop
 
 -- If we run @quickCheck prop_dieHard@ we get:
 --

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -168,13 +168,12 @@ sm prb = StateMachine
 
 prop_references :: Problem -> Property
 prop_references prb = monadicSequential (sm prb) $ \prog -> do
-  (hist, model, prop) <- runCommands (sm prb) prog
-  prettyCommands prog hist model $
-    checkCommandNames prog numberOfConstructors prop
+  (hist, model, prop) <- runProgram (sm prb) prog
+  prettyProgram prog hist model $
+    checkActionNames prog numberOfConstructors prop
   where
   numberOfConstructors = 4
 
 prop_referencesParallel :: Problem -> Property
 prop_referencesParallel prb = monadicParallel (sm prb) $ \prog -> do
-  hps <- runParallelCommands' (sm prb) prog
-  prettyParallelCommands' prog hps
+  prettyParallelProgram prog =<< runParallelProgram (sm prb) prog

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -29,7 +29,6 @@ module MutableReference
   , prop_referencesParallel
   ) where
 
-import           Control.Monad (replicateM_)
 import           Control.Concurrent
                    (threadDelay)
 import           Data.Functor.Classes
@@ -171,7 +170,9 @@ prop_references :: Problem -> Property
 prop_references prb = monadicSequential (sm prb) $ \prog -> do
   (hist, model, prop) <- runCommands (sm prb) prog
   prettyCommands prog hist model $
-    checkCommandNames prog 4 prop
+    checkCommandNames prog numberOfConstructors prop
+  where
+  numberOfConstructors = 4
 
 prop_referencesParallel :: Problem -> Property
 prop_referencesParallel prb = monadicParallel (sm prb) $ \prog -> do

--- a/example/src/MutableReference/Prop.hs
+++ b/example/src/MutableReference/Prop.hs
@@ -128,10 +128,10 @@ prop_shrinkParallelMinimal = shrinkPropertyHelper (prop_referencesParallel RaceC
   hasMinimalShrink :: Fork (Program Action) -> Bool
   hasMinimalShrink
     = anyTree isMinimal
-    . unfoldTree (id &&& shrinker')
+    . unfoldTree (id &&& shrinker'')
     where
-    shrinker' :: Fork (Program Action) -> [Fork (Program Action)]
-    shrinker'
+    shrinker'' :: Fork (Program Action) -> [Fork (Program Action)]
+    shrinker''
       = map unParallelProgram
       . shrinkParallelProgram shrinker precondition transition initModel
       . ParallelProgram

--- a/example/src/MutableReference/Prop.hs
+++ b/example/src/MutableReference/Prop.hs
@@ -184,7 +184,7 @@ instance Read (Internal Action) where
 
   readListPrec = readListPrecDefault
 
-deriving instance Eq1 v => Eq   (Action v resp)
+deriving instance Eq1 v => Eq (Action v resp)
 
 instance Eq (Internal Action) where
   Internal act1 sym1 == Internal act2 sym2 =

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -24,11 +24,17 @@ module TicketDispenser
   , prop_ticketDispenserParallelBad
   ) where
 
+import           Control.Monad
+                   (replicateM_)
 import           Data.Char
                    (isSpace)
+import           Data.Dynamic
+                   (cast)
+import           Data.Functor.Classes
+                   (Eq1(..))
 import           Data.Functor.Classes
                    (Show1)
-import           Prelude                          hiding
+import           Prelude                                  hiding
                    (readFile)
 import           System.Directory
                    (removePathForcibly)
@@ -39,9 +45,16 @@ import           System.IO
 import           System.IO.Strict
                    (readFile)
 import           Test.QuickCheck
-                   (Property, frequency, ioProperty, property, (===))
+                   (Property, frequency, property, (===))
+import           Text.ParserCombinators.ReadP
+                   (string)
+import           Text.Read
+                   (choice, lift, readListPrec, readListPrecDefault,
+                   readPrec)
 
 import           Test.StateMachine
+import           Test.StateMachine.Internal.AlphaEquality
+import           Test.StateMachine.Internal.Types
 import           Test.StateMachine.Internal.Utils
                    (shrinkPropertyHelper)
 
@@ -91,15 +104,15 @@ postconditions (Model m) cmd resp = case cmd of
 -- With stateful generation we ensure that the dispenser is reset before
 -- use.
 
-gen :: Generator Model Action
-gen (Model Nothing)  = pure (Untyped Reset)
-gen (Model (Just _)) = frequency
+generator :: Generator Model Action
+generator (Model Nothing)  = pure (Untyped Reset)
+generator (Model (Just _)) = frequency
   [ (1, pure (Untyped Reset))
   , (8, pure (Untyped TakeTicket))
   ]
 
-shrink1 :: Action v resp -> [Action v resp]
-shrink1 _ = []
+shrinker :: Action v resp -> [Action v resp]
+shrinker _ = []
 
 ------------------------------------------------------------------------
 
@@ -147,24 +160,34 @@ instance HFoldable Action
 
 ------------------------------------------------------------------------
 
+sm :: SharedExclusive -> (FilePath, FilePath) -> StateMachine Model Action IO
+sm se files = StateMachine
+  generator shrinker preconditions transitions
+  postconditions initModel (semantics se files) id
+
 -- Sequentially the model is consistant (even though the lock is
 -- shared).
 
 prop_ticketDispenser :: Property
-prop_ticketDispenser = forAllProgram gen shrink1 preconditions transitions initModel $
-  runAndCheckProgram preconditions transitions postconditions initModel sem ioProperty
+prop_ticketDispenser = monadicSequential sm' $ \prog -> do
+  (hist, model, prop) <- runCommands sm' prog
+  prettyCommands prog hist model $
+    checkCommandNames prog 2 prop
   where
-  sem = semantics Shared (ticketDb, ticketLock)
-  -- Predefined files are used for the database and the file lock.
-  ticketDb, ticketLock :: FilePath
-  ticketDb   = "/tmp/ticket-dispenser.db"
-  ticketLock = "/tmp/ticket-dispenser.lock"
+  sm' = sm Shared (ticketDb, ticketLock)
+    where
+    -- Predefined files are used for the database and the file lock.
+    ticketDb, ticketLock :: FilePath
+    ticketDb   = "/tmp/ticket-dispenser.db"
+    ticketLock = "/tmp/ticket-dispenser.lock"
 
 prop_ticketDispenserParallel :: SharedExclusive -> Property
 prop_ticketDispenserParallel se =
-  forAllParallelProgram gen shrink1 preconditions transitions initModel $ \parallel ->
-    runParallelProgram' setup (semantics se) cleanup parallel $
-    checkParallelProgram transitions postconditions initModel parallel
+  bracketP setup cleanup $ \files ->
+    monadicParallel (sm se files) $ \prog -> do
+      replicateM_ 2000 $ do
+        (hist, prop) <- runParallelCommands (sm se files) prog
+        prettyParallelCommands prog hist prop
   where
 
   -- In the parallel case we create a temporary files for the database and
@@ -192,10 +215,32 @@ prop_ticketDispenserParallelOK = prop_ticketDispenserParallel Exclusive
 prop_ticketDispenserParallelBad :: Property
 prop_ticketDispenserParallelBad =
   shrinkPropertyHelper (prop_ticketDispenserParallel Shared) $ \output ->
-    let counterExample = dropWhile isSpace (lines output !! 1) in
-    counterExample `elem`
-      [ "Fork [Reset] [] [Reset]"
-      , "Fork [TakeTicket] [Reset] [TakeTicket]"
-      , "Fork [TakeTicket] [Reset] [Reset]"
-      , "Fork [Reset] [Reset] [TakeTicket]"
+    let counterExample = read (dropWhile isSpace (lines output !! 1)) in
+    any (alphaEqFork counterExample)
+      [ fork [iact Reset 0]      []             [iact Reset 1]
+      , fork [iact TakeTicket 0] [iact Reset 1] [iact TakeTicket 2]
+      , fork [iact Reset 0]      [iact Reset 1] [iact TakeTicket 2]
+      , fork [iact TakeTicket 0] [iact Reset 1] [iact Reset 2]
       ]
+    where
+    fork l p r = Fork (Program l) (Program p) (Program r)
+    iact act n = Internal act (Symbolic (Var n))
+
+------------------------------------------------------------------------
+
+-- Instances needed for the last property.
+
+instance Read (Internal Action) where
+
+  readPrec = choice
+    [ Internal <$> (Reset      <$ lift (string "Reset"))      <*> readPrec
+    , Internal <$> (TakeTicket <$ lift (string "TakeTicket")) <*> readPrec
+    ]
+
+  readListPrec = readListPrecDefault
+
+deriving instance Eq1 v => Eq (Action v resp)
+
+instance Eq (Internal Action) where
+  Internal act1 sym1 == Internal act2 sym2 =
+    cast act1 == Just act2 && cast sym1 == Just sym2

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -183,7 +183,7 @@ prop_ticketDispenserParallel :: SharedExclusive -> Property
 prop_ticketDispenserParallel se =
   bracketP setup cleanup $ \files ->
     monadicParallel (sm se files) $ \prog ->
-      prettyParallelProgram prog =<< runParallelProgram' 2000 (sm se files) prog
+      prettyParallelProgram prog =<< runParallelProgram' 200 (sm se files) prog
   where
 
   -- In the parallel case we create a temporary files for the database and

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -183,7 +183,7 @@ prop_ticketDispenserParallel :: SharedExclusive -> Property
 prop_ticketDispenserParallel se =
   bracketP setup cleanup $ \files ->
     monadicParallel (sm se files) $ \prog ->
-      prettyParallelProgram prog =<< runParallelProgram' 200 (sm se files) prog
+      prettyParallelProgram prog =<< runParallelProgram' 100 (sm se files) prog
   where
 
   -- In the parallel case we create a temporary files for the database and

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -28,8 +28,7 @@ import           Data.Typeable
                    (Typeable)
 import           Test.QuickCheck
                    (Arbitrary, Property, arbitrary, elements,
-                   frequency, ioProperty, property, shrink, (.&&.),
-                   (.||.), (===))
+                   frequency, property, shrink, (.&&.), (.||.), (===))
 
 import           Test.StateMachine
 
@@ -154,8 +153,8 @@ postconditions m act resp = case act of
 
 ------------------------------------------------------------------------
 
-gen :: (Arbitrary a, Typeable a) => Generator (Model a) (Action a)
-gen (Model m)
+generator :: (Arbitrary a, Typeable a) => Generator (Model a) (Action a)
+generator (Model m)
   | null m    = Untyped . New <$> arbitrary
   | otherwise = frequency
       [ (1, Untyped . New <$> arbitrary)
@@ -165,9 +164,9 @@ gen (Model m)
     where
     ref = elements . map fst
 
-shrink1 :: Arbitrary a => Action a v resp -> [Action a v resp]
-shrink1 (New x) = [ New x' | x' <- shrink x ]
-shrink1 _       = []
+shrinker :: Arbitrary a => Action a v resp -> [Action a v resp]
+shrinker (New x) = [ New x' | x' <- shrink x ]
+shrinker _       = []
 
 ------------------------------------------------------------------------
 
@@ -191,8 +190,14 @@ instance Show a => Show (Untyped (Action a)) where
 
 ------------------------------------------------------------------------
 
+gen :: Generation (Model Int) (Action Int) IO
+gen = Generation generator shrinker preconditions transitions initModel id
+
+exec :: Execution (Model Int) (Action Int) IO
+exec = Execution preconditions transitions postconditions initModel semantics
+
 prop_unionFind :: Property
-prop_unionFind = forAllProgram gen shrink1 preconditions transitions model $
-  runAndCheckProgram preconditions transitions postconditions model semantics ioProperty
-  where
-    model = initModel :: Model Int v
+prop_unionFind = monadicSequential' gen $ \prog -> do
+  (hist, model, prop) <- runProgram exec prog
+  prettyCommands prog hist model $
+    checkCommandNames prog 4 prop

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -199,4 +199,4 @@ prop_unionFind :: Property
 prop_unionFind = monadicSequential sm $ \prog -> do
   (hist, model, prop) <- runProgram sm prog
   prettyProgram prog hist model $
-    checkActionNames prog 4 prop
+    checkActionNames prog 3 prop

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -190,14 +190,13 @@ instance Show a => Show (Untyped (Action a)) where
 
 ------------------------------------------------------------------------
 
-gen :: Generation (Model Int) (Action Int) IO
-gen = Generation generator shrinker preconditions transitions initModel id
-
-exec :: Execution (Model Int) (Action Int) IO
-exec = Execution preconditions transitions postconditions initModel semantics
+sm :: StateMachine (Model Int) (Action Int) IO
+sm = StateMachine
+  generator shrinker preconditions transitions
+  postconditions initModel semantics id
 
 prop_unionFind :: Property
-prop_unionFind = monadicSequential' gen $ \prog -> do
-  (hist, model, prop) <- runProgram exec prog
-  prettyCommands prog hist model $
-    checkCommandNames prog 4 prop
+prop_unionFind = monadicSequential sm $ \prog -> do
+  (hist, model, prop) <- runProgram sm prog
+  prettyProgram prog hist model $
+    checkActionNames prog 4 prop

--- a/example/test/CrudWebserverDbSpec.hs
+++ b/example/test/CrudWebserverDbSpec.hs
@@ -12,14 +12,14 @@ import           CrudWebserverDb
 spec :: Spec
 spec = do
 
-  modifyMaxSuccess (const 30) $
+  modifyMaxSuccess (const 10) $
 
     describe "Sequential property" $
 
-    it "`prop_crudWebserverDb`: sequential property holds" $
-      prop_crudWebserverDb
+      it "`prop_crudWebserverDb`: sequential property holds" $
+        prop_crudWebserverDb
 
-  modifyMaxSuccess (const 20) $
+  modifyMaxSuccess (const 3) $
 
     describe "Parallel property" $
 

--- a/example/test/TicketDispenserSpec.hs
+++ b/example/test/TicketDispenserSpec.hs
@@ -18,7 +18,8 @@ spec = do
 
   describe "Parallel property" $ do
 
-    modifyMaxSuccess (const 10) $
+    modifyMaxSuccess (const 10) $ do
+
       it "`prop_ticketDispenserParallelOK`: works with exclusive file locks"
         prop_ticketDispenserParallelOK
 

--- a/example/test/TicketDispenserSpec.hs
+++ b/example/test/TicketDispenserSpec.hs
@@ -1,7 +1,7 @@
 module TicketDispenserSpec (spec) where
 
 import           Test.Hspec
-                   (Spec, describe, it, xit)
+                   (Spec, describe, it)
 import           Test.Hspec.QuickCheck
                    (modifyMaxSuccess)
 
@@ -22,5 +22,5 @@ spec = do
       it "`prop_ticketDispenserParallelOK`: works with exclusive file locks"
         prop_ticketDispenserParallelOK
 
-    xit "`prop_ticketDispenserParallelBad`: counterexample is found when file locks are shared"
-      prop_ticketDispenserParallelBad
+      it "`prop_ticketDispenserParallelBad`: counterexample is found when file locks are shared"
+        prop_ticketDispenserParallelBad

--- a/example/test/TicketDispenserSpec.hs
+++ b/example/test/TicketDispenserSpec.hs
@@ -18,10 +18,12 @@ spec = do
 
   describe "Parallel property" $ do
 
-    modifyMaxSuccess (const 10) $ do
+    modifyMaxSuccess (const 5) $
 
       it "`prop_ticketDispenserParallelOK`: works with exclusive file locks"
         prop_ticketDispenserParallelOK
+
+    modifyMaxSuccess (const 5) $
 
       it "`prop_ticketDispenserParallelBad`: counterexample is found when file locks are shared"
         prop_ticketDispenserParallelBad

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -18,6 +18,7 @@ tested-with:         GHC == 8.0.2
 library
   hs-source-dirs:      src
   exposed-modules:     Test.StateMachine
+                     , Test.StateMachine.Deprecated
                      , Test.StateMachine.Internal.AlphaEquality
                      , Test.StateMachine.Internal.Parallel
                      , Test.StateMachine.Internal.ScopeCheck

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -18,7 +18,6 @@ tested-with:         GHC == 8.0.2
 library
   hs-source-dirs:      src
   exposed-modules:     Test.StateMachine
-                     , Test.StateMachine.Deprecated
                      , Test.StateMachine.Internal.AlphaEquality
                      , Test.StateMachine.Internal.Parallel
                      , Test.StateMachine.Internal.ScopeCheck
@@ -29,6 +28,7 @@ library
                      , Test.StateMachine.Internal.Utils.BoxDrawer
                      , Test.StateMachine.Types
                      , Test.StateMachine.Types.HFunctor
+                     , Test.StateMachine.Types.History
                      , Test.StateMachine.Types.References
   build-depends:       ansi-wl-pprint (>=0.6.7.3 && <0.7)
                      , async

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -33,6 +33,9 @@ library
                      , async
                      , base (>=4.7 && <5)
                      , containers (>=0.5.7.1 && <0.6)
+                     , lifted-async
+                     , lifted-base
+                     , monad-control
                      , mtl (>=2.2.1 && <2.3)
                      , QuickCheck (>=2.9.2 && <2.10)
                      , random (==1.1.*)

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -51,6 +51,7 @@ module Test.StateMachine
   , module Test.StateMachine.Types
 
     -- * Rexport
+  , bracketP
   , Test.QuickCheck.quickCheck
   ) where
 
@@ -81,7 +82,7 @@ import           Test.StateMachine.Internal.Sequential
 import           Test.StateMachine.Internal.Types
 import           Test.StateMachine.Internal.Types.Environment
 import           Test.StateMachine.Internal.Utils
-                   (liftProperty, whenFailM)
+                   (liftProperty, whenFailM, bracketP)
 import           Test.StateMachine.Types
 
 ------------------------------------------------------------------------
@@ -135,8 +136,6 @@ runCommands
   -> Program act
   -> PropertyM m (History act, model Concrete, Property)
 runCommands sm = run . runCommands' sm
-
-
 
 runCommands'
   :: forall m act model

--- a/src/Test/StateMachine/Internal/Sequential.hs
+++ b/src/Test/StateMachine/Internal/Sequential.hs
@@ -29,7 +29,7 @@ module Test.StateMachine.Internal.Sequential
   where
 
 import           Control.Monad
-                   (filterM, foldM_, when)
+                   (filterM, foldM, when)
 import           Control.Monad.State
                    (State, StateT, evalState, get, lift, put)
 import           Data.Dynamic

--- a/src/Test/StateMachine/Internal/Sequential.hs
+++ b/src/Test/StateMachine/Internal/Sequential.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -----------------------------------------------------------------------------
@@ -23,26 +24,29 @@ module Test.StateMachine.Internal.Sequential
   , getUsedVars
   , liftShrinkInternal
   , shrinkProgram
-  , checkProgram
+  , executeProgram
   )
   where
 
 import           Control.Monad
                    (filterM, foldM_, when)
 import           Control.Monad.State
-                   (State, StateT, get, lift, modify, put, evalState)
+                   (State, StateT, evalState, get, lift, put)
+import           Data.Dynamic
+                   (toDyn)
+import           Data.Monoid
+                   ((<>))
 import           Data.Set
                    (Set)
 import qualified Data.Set                                     as S
 import           Test.QuickCheck
-                   (Gen, shrinkList, sized, choose, suchThat)
-import           Test.QuickCheck.Monadic
-                   (PropertyM, pre, run)
+                   (Gen, Property, choose, counterexample, property,
+                   shrinkList, sized, suchThat, (.&&.))
 
 import           Test.StateMachine.Internal.Types
 import           Test.StateMachine.Internal.Types.Environment
-import           Test.StateMachine.Internal.Utils
 import           Test.StateMachine.Types
+import           Test.StateMachine.Types.History
 
 ------------------------------------------------------------------------
 
@@ -117,36 +121,47 @@ shrinkProgram shrinker precondition transition model
   . shrinkList (liftShrinkInternal shrinker)
   . unProgram
 
--- | For each action in a program, check that if the pre-condition holds
---   for the action, then so does the post-condition.
-checkProgram
-  :: Monad m
+executeProgram
+  :: forall m act model
+  .  Monad m
+  => Show (Untyped act)
   => HFunctor act
-  => Precondition  model act
-  -> Transition    model act
-  -> Postcondition model act
-  -> model Symbolic  -- ^ The model with symbolic references is used to
-                     -- check pre-conditions against.
-  -> model Concrete  -- ^ While the one with concrete referenes is used
-                     -- for checking post-conditions.
-  -> Semantics act m
-  -> Program   act
-  -> PropertyM (StateT Environment m) ()
-checkProgram precondition transition postcondition smodel0 cmodel0 semantics
-  = foldM_ go (smodel0, cmodel0)
+  => StateMachine  model act m
+  -> Program act
+  -> m (History act, model Concrete, Property)
+executeProgram StateMachine {..}
+  = fmap (\(hist, _, cmodel, _, prop) -> (hist, cmodel, prop))
+  . foldM go (mempty, model', model', emptyEnvironment, property True)
   . unProgram
   where
-  go (smodel, cmodel) (Internal act sym) = do
-    pre (precondition smodel act)
-    env <- run get
-    let cact = hfmap (fromSymbolic env) act
-    resp <- run (lift (semantics cact))
-    liftProperty (postcondition cmodel cact resp)
-    let cresp = Concrete resp
-    run (modify (insertConcrete sym cresp))
-    return (transition smodel act sym, transition cmodel cact cresp)
+  go :: (History act, model Symbolic, model Concrete, Environment, Property)
+     -> Internal act
+     -> m (History act, model Symbolic, model Concrete, Environment, Property)
+  go (hist, smodel, cmodel, env, prop) (Internal act sym@(Symbolic var)) = do
+    if not (precondition' smodel act)
+    then
+      return ( hist
+             , smodel
+             , cmodel
+             , env
+             , counterexample ("precondition failed for: " ++ show (Untyped act)) prop
+             )
+    else do
+      let cact = hfmap (fromSymbolic env) act
+      resp <- semantics' cact
+      let cresp = Concrete resp
+          hist' = History
+            [ InvocationEvent (UntypedConcrete cact) (show (Untyped act)) var (Pid 0)
+            , ResponseEvent (toDyn cresp) (show resp) (Pid 0)
+            ]
+      return ( hist <> hist'
+             , transition' smodel act sym
+             , transition' cmodel cact cresp
+             , insertConcrete sym cresp env
+             , prop .&&. postcondition' cmodel cact resp
+             )
     where
     fromSymbolic :: Environment -> Symbolic v ->  Concrete v
-    fromSymbolic env sym' = case reifyEnvironment env sym' of
+    fromSymbolic env' sym' = case reifyEnvironment env' sym' of
       Left  err -> error (show err)
       Right con -> con

--- a/src/Test/StateMachine/Internal/Types.hs
+++ b/src/Test/StateMachine/Internal/Types.hs
@@ -20,6 +20,7 @@
 
 module Test.StateMachine.Internal.Types
   ( Program(..)
+  , programLength
   , ParallelProgram(..)
   , Pid(..)
   , Fork(..)
@@ -67,6 +68,9 @@ instance (Show (Untyped act), HFoldable act) => Show (Program act) where
 instance Read (Internal act) => Read (Program act) where
   readPrec     = Program <$> readPrec
   readListPrec = readListPrecDefault
+
+programLength :: Program act -> Int
+programLength = length . unProgram
 
 ------------------------------------------------------------------------
 

--- a/src/Test/StateMachine/Internal/Utils.hs
+++ b/src/Test/StateMachine/Internal/Utils.hs
@@ -16,6 +16,7 @@
 module Test.StateMachine.Internal.Utils
   ( anyP
   , liftProperty
+  , whenFailM
   , shrinkPropertyHelper
   , shrinkPropertyHelper'
   , shrinkPair
@@ -24,7 +25,8 @@ module Test.StateMachine.Internal.Utils
 
 import           Test.QuickCheck
                    (Property, Result(Failure), chatty, counterexample,
-                   output, property, quickCheckWithResult, stdArgs)
+                   output, property, quickCheckWithResult, stdArgs,
+                   whenFail)
 import           Test.QuickCheck.Monadic
                    (PropertyM(MkPropertyM), monadicIO, run)
 import           Test.QuickCheck.Property
@@ -39,6 +41,9 @@ anyP p = foldr (\x ih -> p x .||. ih) (property False)
 -- | Lifts a plain property into a monadic property.
 liftProperty :: Monad m => Property -> PropertyM m ()
 liftProperty prop = MkPropertyM (\k -> fmap (prop .&&.) <$> k ())
+
+whenFailM :: Monad m => IO () -> Property -> PropertyM m ()
+whenFailM m prop = liftProperty (m `whenFail` prop)
 
 -- | Write a metaproperty on the output of QuickChecking a property using a
 --   boolean predicate on the output.

--- a/src/Test/StateMachine/Internal/Utils.hs
+++ b/src/Test/StateMachine/Internal/Utils.hs
@@ -18,6 +18,7 @@ module Test.StateMachine.Internal.Utils
   , liftProperty
   , whenFailM
   , bracketP
+  , alwaysP
   , shrinkPropertyHelper
   , shrinkPropertyHelper'
   , shrinkPair

--- a/src/Test/StateMachine/Internal/Utils.hs
+++ b/src/Test/StateMachine/Internal/Utils.hs
@@ -52,6 +52,14 @@ bracketP :: IO a -> (a -> IO b) -> (a -> Property) -> Property
 bracketP up down prop = ioProperty $
   bracketOnError up down (return . prop)
 
+-- | A property that tests @prop@ repeatedly @n@ times, failing as soon as any
+--   of the tests of @prop@ fails.
+alwaysP :: Int -> Property -> Property
+alwaysP n prop
+  | n <= 0    = error "alwaysP: expected positive integer."
+  | n == 1    = prop
+  | otherwise = prop .&&. alwaysP (n - 1) prop
+
 -- | Write a metaproperty on the output of QuickChecking a property using a
 --   boolean predicate on the output.
 shrinkPropertyHelper :: Property -> (String -> Bool) -> Property

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -23,6 +23,7 @@ module Test.StateMachine.Types
     Untyped(..)
 
     -- * Type aliases
+  , StateMachine(..)
   , Generator
   , Shrinker
   , Precondition
@@ -63,6 +64,17 @@ data Untyped (act :: (* -> *) -> * -> *) where
   Untyped :: (Show resp, Typeable resp) => act Symbolic resp -> Untyped act
 
 ------------------------------------------------------------------------
+
+data StateMachine model act m = StateMachine
+  { generator'     :: Generator model act
+  , shrinker'      :: Shrinker  act
+  , precondition'  :: Precondition model act
+  , transition'    :: Transition   model act
+  , postcondition' :: Postcondition model act
+  , model'         :: InitialModel model
+  , semantics'     :: Semantics act m
+  , runner'        :: Runner m
+  }
 
 -- | When generating actions we have access to a model containing
 --   symbolic references.

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -27,9 +27,10 @@ module Test.StateMachine.Types
   , Shrinker
   , Precondition
   , Transition
-  , Semantics
   , Postcondition
   , InitialModel
+  , Semantics
+  , Runner
 
   -- * Higher-order functors, foldables and traversables
   , module Test.StateMachine.Types.HFunctor
@@ -81,9 +82,6 @@ type Precondition model act = forall resp.
 type Transition model act = forall resp v. Ord1 v =>
   model v -> act v resp -> v resp -> model v
 
--- | When we execute our actions we have access to concrete references.
-type Semantics act m = forall resp. act Concrete resp -> m resp
-
 -- | Post-conditions are checked after the actions have been executed
 --   and we got a response.
 type Postcondition model act = forall resp.
@@ -93,3 +91,9 @@ type Postcondition model act = forall resp.
 --   so that it can be used both in the pre- and the post-condition
 --   check.
 type InitialModel m = forall (v :: * -> *). m v
+
+-- | When we execute our actions we have access to concrete references.
+type Semantics act m = forall resp. act Concrete resp -> m resp
+
+-- | How to run the monad used by the semantics.
+type Runner m = m Property -> IO Property

--- a/src/Test/StateMachine/Types/History.hs
+++ b/src/Test/StateMachine/Types/History.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+
+module Test.StateMachine.Types.History where
+
+import           Data.Dynamic
+                   (Dynamic)
+import           Data.Typeable
+                   (Typeable)
+import           Test.StateMachine.Internal.Types
+import           Test.StateMachine.Types
+
+------------------------------------------------------------------------
+
+-- | A history is a trace of invocations and responses from running a
+--   parallel program.
+newtype History act = History
+  { unHistory :: History' act }
+  deriving Monoid
+
+ppHistory :: History act -> String
+ppHistory = foldr go "" . unHistory
+  where
+  go :: HistoryEvent (UntypedConcrete act) -> String -> String
+  go (InvocationEvent _ str _ _) ih = " " ++ str ++ " ==> " ++ ih
+  go (ResponseEvent   _ str   _) ih =        str ++ "\n"    ++ ih
+
+type History' act = [HistoryEvent (UntypedConcrete act)]
+
+data UntypedConcrete (act :: (* -> *) -> * -> *) where
+  UntypedConcrete :: (Show resp, Typeable resp) =>
+    act Concrete resp -> UntypedConcrete act
+
+data HistoryEvent act
+  = InvocationEvent act     String Var Pid
+  | ResponseEvent   Dynamic String     Pid
+
+getProcessIdEvent :: HistoryEvent act -> Pid
+getProcessIdEvent (InvocationEvent _ _ _ pid) = pid
+getProcessIdEvent (ResponseEvent   _ _ pid)   = pid
+
+data Operation act = forall resp. Typeable resp =>
+  Operation (act Concrete resp) String (Concrete resp) Pid
+
+takeInvocations :: [HistoryEvent a] -> [HistoryEvent a]
+takeInvocations = takeWhile $ \h -> case h of
+  InvocationEvent {} -> True
+  _                  -> False
+
+findCorrespondingResp :: Pid -> History' act -> [(Dynamic, History' act)]
+findCorrespondingResp _   [] = []
+findCorrespondingResp pid (ResponseEvent resp _ pid' : es) | pid == pid' = [(resp, es)]
+findCorrespondingResp pid (e : es) =
+  [ (resp, e : es') | (resp, es') <- findCorrespondingResp pid es ]


### PR DESCRIPTION
Had a go at refactoring the combinators. Not entirely sure about the design choices yet.

If the post-condition would be boolean, we could have `runCommands` return a `Result = Ok | PreCondFailed | PostCondFailed...` and then do:

```haskell
(hist, model, res) <- runCommands prog
print hist `whenFail` res === Ok
```

Which would be closer to what they do in Erlang, https://github.com/Quviq/QuickCheckExamples/blob/master/src/crud_eqc.erl.

Also managed to unify the semantics/runners of sequential and parallel by using `lifted-async`, it could be argued that `MonadBaseControl` complicates things though...

What do you reckon?