### PR TITLE
Integrate Quickcheck with counterexamples

### DIFF
--- a/example/quickcheck-state-machine-example.cabal
+++ b/example/quickcheck-state-machine-example.cabal
@@ -31,6 +31,7 @@ library
                      , persistent-template
                      , QuickCheck
                      , quickcheck-instances
+                     , quickcheck-with-counterexamples
                      , quickcheck-state-machine
                      , random
                      , resourcet
@@ -53,6 +54,7 @@ test-suite quickcheck-state-machine-example-test
                      , CrudWebserverDbSpec
                      , CrudWebserverFileSpec
                      , DieHardSpec
+                     , HspecInstance
                      , MutableReferenceSpec
                      , Spec
                      , TicketDispenserSpec
@@ -60,7 +62,9 @@ test-suite quickcheck-state-machine-example-test
   build-depends:       base
                      , containers
                      , hspec
+                     , hspec-core
                      , QuickCheck
+                     , quickcheck-with-counterexamples
                      , quickcheck-state-machine
                      , quickcheck-state-machine-example
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/example/src/CircularBuffer.hs
+++ b/example/src/CircularBuffer.hs
@@ -79,6 +79,14 @@ instance HTraversable Action where
   htraverse f (Get buffer)   = Get <$> htraverse f buffer
   htraverse f (Len buffer)   = Len <$> htraverse f buffer
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    New{} -> "New"
+    Put{} -> "Put"
+    Get{} -> "Get"
+    Len{} -> "Len"
+  nConstructors _ = 4
+
 ------------------------------------------------------------------------
 
 -- | A simple, persistent, inefficient buffer.
@@ -246,7 +254,7 @@ prepropcircularBuffer version bugs =
   monadicSequential sm' $ \prog -> do
     (hist, model, prop) <- runProgram sm' prog
     prettyProgram prog hist model $
-      checkActionNames prog 4 prop
+      checkActionNames prog prop
   where
   sm' = sm version bugs
 

--- a/example/src/CrudWebserverDb.hs
+++ b/example/src/CrudWebserverDb.hs
@@ -327,6 +327,14 @@ instance HTraversable Action where
 instance HFunctor  Action
 instance HFoldable Action
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    PostUser{}   -> "PostUser"
+    GetUser{}    -> "GetUser"
+    IncAgeUser{} -> "IncAgeUser"
+    DeleteUser{} -> "DeleteUser"
+  nConstructors _ = 4
+
 ------------------------------------------------------------------------
 
 -- Finally we got all pieces needed to write a sequential and a parallel
@@ -344,7 +352,7 @@ prop_crudWebserverDb =
     monadicSequential (sm port) $ \prog -> do
       (hist, model, prop) <- runProgram (sm port) prog
       prettyProgram prog hist model $
-        checkActionNames prog 4 prop
+        checkActionNames prog prop
   where
   port = 8081
 

--- a/example/src/CrudWebserverFile.hs
+++ b/example/src/CrudWebserverFile.hs
@@ -214,6 +214,13 @@ instance HFoldable Action
 instance Show (Untyped Action) where
   show (Untyped act) = show act
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    PutFile{}    -> "PutFile"
+    GetFile{}    -> "GetFile"
+    DeleteFile{} -> "DeleteFile"
+  nConstructors _ = 3
+
 ------------------------------------------------------------------------
 
 burl :: BaseUrl
@@ -247,7 +254,7 @@ prop_crudWebserverFile =
     monadicSequential sm $ \prog -> do
       (hist, model, prop) <- runProgram sm prog
       prettyProgram prog hist model $
-        checkActionNames prog 3 prop
+        checkActionNames prog prop
 
 prop_crudWebserverFileParallel :: Property
 prop_crudWebserverFileParallel =

--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -30,6 +30,8 @@ import           Data.Functor.Classes
                    (Show1)
 import           Test.QuickCheck
                    (Property, elements, property)
+import           Test.QuickCheck.Counterexamples
+                   (PropertyOf)
 
 import           Test.StateMachine
 
@@ -171,8 +173,8 @@ sm = StateMachine
   generator shrinker preconditions transitions
   postconditions initModel semantics id
 
-prop_dieHard :: Property
-prop_dieHard = monadicSequential sm $ \prog -> do
+prop_dieHard :: PropertyOf (Program Action)
+prop_dieHard = monadicSequentialC sm $ \prog -> do
   (hist, model, prop) <- runProgram sm prog
   prettyProgram prog hist model $
     checkActionNames prog prop

--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -29,7 +29,7 @@ module DieHard
 import           Data.Functor.Classes
                    (Show1)
 import           Test.QuickCheck
-                   (Property, elements, property)
+                   (elements, property)
 import           Test.QuickCheck.Counterexamples
                    (PropertyOf)
 

--- a/example/src/DieHard.hs
+++ b/example/src/DieHard.hs
@@ -149,6 +149,16 @@ instance HTraversable Action where
   htraverse _ SmallIntoBig = pure SmallIntoBig
   htraverse _ BigIntoSmall = pure BigIntoSmall
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    FillBig      -> "FillBig"
+    FillSmall    -> "FillSmall"
+    EmptyBig     -> "EmptyBig"
+    EmptySmall   -> "EmptySmall"
+    SmallIntoBig -> "SmallIntoBig"
+    BigIntoSmall -> "BigIntoSmall"
+  nConstructors _ = 6
+
 ------------------------------------------------------------------------
 
 -- Finally we have all the pieces needed to get the sequential property!
@@ -165,7 +175,7 @@ prop_dieHard :: Property
 prop_dieHard = monadicSequential sm $ \prog -> do
   (hist, model, prop) <- runProgram sm prog
   prettyProgram prog hist model $
-    checkActionNames prog 4 prop
+    checkActionNames prog prop
 
 -- If we run @quickCheck prop_dieHard@ we get:
 --

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -41,6 +41,8 @@ import           System.Random
 import           Test.QuickCheck
                    (Property, arbitrary, elements, frequency, property,
                    shrink, (===))
+import           Test.QuickCheck.Counterexamples
+                   (PropertyOf)
 
 import           Test.StateMachine
 
@@ -174,12 +176,12 @@ sm prb = StateMachine
   generator shrinker precondition transition
   postcondition initModel (semantics prb) id
 
-prop_references :: Problem -> Property
-prop_references prb = monadicSequential (sm prb) $ \prog -> do
+prop_references :: Problem -> PropertyOf (Program Action)
+prop_references prb = monadicSequentialC (sm prb) $ \prog -> do
   (hist, model, prop) <- runProgram (sm prb) prog
   prettyProgram prog hist model $
     checkActionNames prog prop
 
-prop_referencesParallel :: Problem -> Property
-prop_referencesParallel prb = monadicParallel (sm prb) $ \prog -> do
+prop_referencesParallel :: Problem -> PropertyOf (ParallelProgram Action)
+prop_referencesParallel prb = monadicParallelC (sm prb) $ \prog -> do
   prettyParallelProgram prog =<< runParallelProgram (sm prb) prog

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -39,8 +39,8 @@ import           Data.IORef
 import           System.Random
                    (randomRIO)
 import           Test.QuickCheck
-                   (Property, arbitrary, elements, frequency, property,
-                   shrink, (===))
+                   (arbitrary, elements, frequency, property, shrink,
+                   (===))
 import           Test.QuickCheck.Counterexamples
                    (PropertyOf)
 

--- a/example/src/MutableReference.hs
+++ b/example/src/MutableReference.hs
@@ -149,6 +149,14 @@ instance HTraversable Action where
 instance HFunctor  Action
 instance HFoldable Action
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    New     -> "New"
+    Read{}  -> "Read"
+    Write{} -> "Write"
+    Inc{}   -> "Inc"
+  nConstructors _ = 4
+
 ------------------------------------------------------------------------
 
 -- If we run @quickCheck (prop_references None)@, then the property
@@ -170,9 +178,7 @@ prop_references :: Problem -> Property
 prop_references prb = monadicSequential (sm prb) $ \prog -> do
   (hist, model, prop) <- runProgram (sm prb) prog
   prettyProgram prog hist model $
-    checkActionNames prog numberOfConstructors prop
-  where
-  numberOfConstructors = 4
+    checkActionNames prog prop
 
 prop_referencesParallel :: Problem -> Property
 prop_referencesParallel prb = monadicParallel (sm prb) $ \prog -> do

--- a/example/src/MutableReference/Prop.hs
+++ b/example/src/MutableReference/Prop.hs
@@ -84,14 +84,16 @@ prop_genParallelSequence = forAll
     vars = map (\(Internal _ (Symbolic (Var i))) -> i) . unProgram
 
 prop_sequentialShrink :: Property
-prop_sequentialShrink = shrinkPropertyHelper (prop_references Bug) $ alphaEq
-  (Program [ Internal New                   sym0
-           , Internal (Write (Reference sym0)  5) (Symbolic (Var 1))
-           , Internal (Read  (Reference sym0))    (Symbolic (Var 2))
-           ])
-  . read . (!! 1) . lines
+prop_sequentialShrink =
+  shrinkPropertyHelperC (prop_references Bug) $ \prog ->
+    alphaEq prog0 prog
   where
-  sym0 = Symbolic (Var 0)
+    sym0 = Symbolic (Var 0)
+    prog0 = Program
+      [ Internal New                   sym0
+      , Internal (Write (Reference sym0)  5) (Symbolic (Var 1))
+      , Internal (Read  (Reference sym0))    (Symbolic (Var 2))
+      ]
 
 cheat :: ParallelProgram Action -> ParallelProgram Action
 cheat = ParallelProgram . fmap go . unParallelProgram
@@ -120,10 +122,12 @@ prop_shrinkParallelScope = forAll
 ------------------------------------------------------------------------
 
 prop_shrinkParallelMinimal :: Property
-prop_shrinkParallelMinimal = shrinkPropertyHelper (prop_referencesParallel RaceCondition) $ \out ->
-  let f :: Fork (Program Action)
-      f = read $ dropWhile isSpace (lines out !! 1)
-  in hasMinimalShrink f || isMinimal f
+prop_shrinkParallelMinimal =
+  shrinkPropertyHelperC (prop_referencesParallel RaceCondition) checkParallelProgram
+
+checkParallelProgram :: ParallelProgram Action -> Bool
+checkParallelProgram (ParallelProgram prog) =
+  hasMinimalShrink prog || isMinimal prog
   where
   hasMinimalShrink :: Fork (Program Action) -> Bool
   hasMinimalShrink
@@ -169,23 +173,9 @@ prop_shrinkParallelMinimal = shrinkPropertyHelper (prop_referencesParallel RaceC
       , Internal (Inc   ref0)   (Symbolic var1)
       ]
 
-instance Read (Reference Symbolic (Opaque (IORef Int))) where
-  readPrec     = Reference . Symbolic <$> readPrec
-  readListPrec = readListPrecDefault
-
-instance Read (Internal Action) where
-
-  readPrec = choice
-    [ Internal <$> (New   <$ lift (string "New"))  <*> readPrec
-    , Internal <$> (Read  <$ lift (string "Read")  <*> readPrec) <*> readPrec
-    , Internal <$> (Write <$ lift (string "Write") <*> readPrec <*> readPrec) <*> readPrec
-    , Internal <$> (Inc   <$ lift (string "Inc")   <*> readPrec) <*> readPrec
-    ]
-
-  readListPrec = readListPrecDefault
+------------------------------------------------------------------------
 
 deriving instance Eq1 v => Eq (Action v resp)
 
-instance Eq (Internal Action) where
-  Internal act1 sym1 == Internal act2 sym2 =
-    cast act1 == Just act2 && cast sym1 == Just sym2
+instance Eq (Untyped Action) where
+  Untyped act1 == Untyped act2 = cast act1 == Just act2

--- a/example/src/MutableReference/Prop.hs
+++ b/example/src/MutableReference/Prop.hs
@@ -24,14 +24,10 @@ import           Control.Monad
                    (void)
 import           Control.Monad.State
                    (evalStateT)
-import           Data.Char
-                   (isSpace)
 import           Data.Dynamic
                    (cast)
 import           Data.Functor.Classes
                    (Eq1(..))
-import           Data.IORef
-                   (IORef)
 import           Data.List
                    (isSubsequenceOf)
 import           Data.Monoid
@@ -40,11 +36,6 @@ import           Data.Tree
                    (Tree(Node), unfoldTree)
 import           Test.QuickCheck
                    (Property, forAll, (===))
-import           Text.ParserCombinators.ReadP
-                   (string)
-import           Text.Read
-                   (choice, lift, readListPrec, readListPrecDefault,
-                   readPrec)
 
 import           Test.StateMachine
 import           Test.StateMachine.Internal.AlphaEquality

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -24,8 +24,6 @@ module TicketDispenser
   , prop_ticketDispenserParallelBad
   ) where
 
-import           Data.Char
-                   (isSpace)
 import           Data.Dynamic
                    (cast)
 import           Data.Functor.Classes
@@ -44,17 +42,12 @@ import           Test.QuickCheck
                    (Property, frequency, property, (===))
 import           Test.QuickCheck.Counterexamples
                    (PropertyOf)
-import           Text.ParserCombinators.ReadP
-                   (string)
-import           Text.Read
-                   (choice, lift, readListPrec, readListPrecDefault,
-                   readPrec)
 
 import           Test.StateMachine
 import           Test.StateMachine.Internal.AlphaEquality
 import           Test.StateMachine.Internal.Types
 import           Test.StateMachine.Internal.Utils
-                   (shrinkPropertyHelper, shrinkPropertyHelperC)
+                   (shrinkPropertyHelperC)
 
 ------------------------------------------------------------------------
 

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -29,9 +29,7 @@ import           Data.Char
 import           Data.Dynamic
                    (cast)
 import           Data.Functor.Classes
-                   (Eq1(..))
-import           Data.Functor.Classes
-                   (Show1)
+                   (Eq1(..), Show1)
 import           Prelude                                  hiding
                    (readFile)
 import           System.Directory
@@ -44,6 +42,8 @@ import           System.IO.Strict
                    (readFile)
 import           Test.QuickCheck
                    (Property, frequency, property, (===))
+import           Test.QuickCheck.Counterexamples
+                   (PropertyOf)
 import           Text.ParserCombinators.ReadP
                    (string)
 import           Text.Read
@@ -54,7 +54,7 @@ import           Test.StateMachine
 import           Test.StateMachine.Internal.AlphaEquality
 import           Test.StateMachine.Internal.Types
 import           Test.StateMachine.Internal.Utils
-                   (shrinkPropertyHelper)
+                   (shrinkPropertyHelper, shrinkPropertyHelperC)
 
 ------------------------------------------------------------------------
 
@@ -185,10 +185,10 @@ prop_ticketDispenser = monadicSequential sm' $ \prog -> do
     ticketDb   = "/tmp/ticket-dispenser.db"
     ticketLock = "/tmp/ticket-dispenser.lock"
 
-prop_ticketDispenserParallel :: SharedExclusive -> Property
+prop_ticketDispenserParallel :: SharedExclusive -> PropertyOf (ParallelProgram Action)
 prop_ticketDispenserParallel se =
-  bracketP setup cleanup $ \files ->
-    monadicParallel (sm se files) $ \prog ->
+  bracketPC setup cleanup $ \files ->
+    monadicParallelC (sm se files) $ \prog ->
       prettyParallelProgram prog =<< runParallelProgram' 100 (sm se files) prog
   where
 
@@ -208,7 +208,7 @@ prop_ticketDispenserParallel se =
 
 -- So long as the file locks are exclusive, i.e. not shared, the
 -- parallel property passes.
-prop_ticketDispenserParallelOK :: Property
+prop_ticketDispenserParallelOK :: PropertyOf (ParallelProgram Action)
 prop_ticketDispenserParallelOK = prop_ticketDispenserParallel Exclusive
 
 -- If we allow file locks to be shared, then we get race conditions as
@@ -216,9 +216,8 @@ prop_ticketDispenserParallelOK = prop_ticketDispenserParallel Exclusive
 -- counterexamples are found.
 prop_ticketDispenserParallelBad :: Property
 prop_ticketDispenserParallelBad =
-  shrinkPropertyHelper (prop_ticketDispenserParallel Shared) $ \output ->
-    let counterExample = read (dropWhile isSpace (lines output !! 1)) in
-    any (alphaEqFork counterExample)
+  shrinkPropertyHelperC (prop_ticketDispenserParallel Shared) $ \(ParallelProgram f) ->
+    any (alphaEqFork f)
       [ fork [iact Reset 0]      []             [iact Reset 1]
       , fork [iact TakeTicket 0] [iact Reset 1] [iact TakeTicket 2]
       , fork [iact Reset 0]      [iact Reset 1] [iact TakeTicket 2]
@@ -232,17 +231,7 @@ prop_ticketDispenserParallelBad =
 
 -- Instances needed for the last property.
 
-instance Read (Internal Action) where
-
-  readPrec = choice
-    [ Internal <$> (Reset      <$ lift (string "Reset"))      <*> readPrec
-    , Internal <$> (TakeTicket <$ lift (string "TakeTicket")) <*> readPrec
-    ]
-
-  readListPrec = readListPrecDefault
-
 deriving instance Eq1 v => Eq (Action v resp)
 
-instance Eq (Internal Action) where
-  Internal act1 sym1 == Internal act2 sym2 =
-    cast act1 == Just act2 && cast sym1 == Just sym2
+instance Eq (Untyped Action) where
+  Untyped act1 == Untyped act2 = cast act1 == Just act2

--- a/example/src/TicketDispenser.hs
+++ b/example/src/TicketDispenser.hs
@@ -156,6 +156,12 @@ instance HTraversable Action where
 instance HFunctor  Action
 instance HFoldable Action
 
+instance Constructors Action where
+  constructor x = Constructor $ case x of
+    TakeTicket -> "TakeTicket"
+    Reset      -> "Reset"
+  nConstructors _ = 2
+
 ------------------------------------------------------------------------
 
 sm :: SharedExclusive -> (FilePath, FilePath) -> StateMachine Model Action IO
@@ -170,7 +176,7 @@ prop_ticketDispenser :: Property
 prop_ticketDispenser = monadicSequential sm' $ \prog -> do
   (hist, model, prop) <- runProgram sm' prog
   prettyProgram prog hist model $
-    checkActionNames prog 2 prop
+    checkActionNames prog prop
   where
   sm' = sm Shared (ticketDb, ticketLock)
     where

--- a/example/src/UnionFind.hs
+++ b/example/src/UnionFind.hs
@@ -188,6 +188,13 @@ instance HFoldable (Action a)
 instance Show a => Show (Untyped (Action a)) where
   show (Untyped act) = show act
 
+instance Constructors (Action a) where
+  constructor x = Constructor $ case x of
+    New{}   -> "New"
+    Find{}  -> "Find"
+    Union{} -> "Union"
+  nConstructors _ = 3
+
 ------------------------------------------------------------------------
 
 sm :: StateMachine (Model Int) (Action Int) IO
@@ -199,4 +206,4 @@ prop_unionFind :: Property
 prop_unionFind = monadicSequential sm $ \prog -> do
   (hist, model, prop) <- runProgram sm prog
   prettyProgram prog hist model $
-    checkActionNames prog 3 prop
+    checkActionNames prog prop

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -3,3 +3,5 @@ packages:
   - '.'
   - location: '..'
     extra-dep: true
+extra-deps:
+  - 'quickcheck-with-counterexamples-1.0'

--- a/example/test/HspecInstance.hs
+++ b/example/test/HspecInstance.hs
@@ -1,0 +1,12 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module HspecInstance where
+
+import           Test.Hspec.Core.Spec
+import           Test.QuickCheck
+                   (property)
+import           Test.QuickCheck.Counterexamples
+                   (PropertyOf)
+
+instance Example (PropertyOf a) where
+  evaluateExample = evaluateExample . property

--- a/example/test/MutableReferenceSpec.hs
+++ b/example/test/MutableReferenceSpec.hs
@@ -5,6 +5,8 @@ import           Test.Hspec
 import           Test.Hspec.QuickCheck
                    (modifyMaxSuccess)
 
+import           HspecInstance
+                   ()
 import           MutableReference
 import           MutableReference.Prop
 

--- a/example/test/TicketDispenserSpec.hs
+++ b/example/test/TicketDispenserSpec.hs
@@ -5,6 +5,8 @@ import           Test.Hspec
 import           Test.Hspec.QuickCheck
                    (modifyMaxSuccess)
 
+import           HspecInstance
+                   ()
 import           TicketDispenser
 
 ------------------------------------------------------------------------

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -18,6 +18,7 @@ tested-with:         GHC == 8.0.2
 library
   hs-source-dirs:      src
   exposed-modules:     Test.StateMachine
+                     , Test.StateMachine.Generics
                      , Test.StateMachine.Internal.AlphaEquality
                      , Test.StateMachine.Internal.Parallel
                      , Test.StateMachine.Internal.ScopeCheck
@@ -39,6 +40,7 @@ library
                      , monad-control
                      , mtl (>=2.2.1 && <2.3)
                      , QuickCheck (>=2.9.2 && <2.10)
+                     , quickcheck-with-counterexamples (< 2.0)
                      , random (==1.1.*)
                      , stm (>=2.4.4.1 && <2.5)
   default-language:    Haskell2010

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -54,8 +54,6 @@ import           Control.Monad.State
                    (evalStateT, replicateM)
 import           Control.Monad.Trans.Control
                    (MonadBaseControl)
-import           Data.Functor.Classes
-                   (Show1)
 import           Data.Map
                    (Map)
 import qualified Data.Map                                     as M

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -54,6 +54,8 @@ import           Control.Monad.State
                    (evalStateT, replicateM)
 import           Control.Monad.Trans.Control
                    (MonadBaseControl)
+import           Data.Functor.Classes
+                   (Show1)
 import           Data.Map
                    (Map)
 import qualified Data.Map                                     as M

--- a/src/Test/StateMachine/Generics.hs
+++ b/src/Test/StateMachine/Generics.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE KindSignatures #-}
+
+module Test.StateMachine.Generics where
+
+newtype Constructor = Constructor String
+  deriving (Eq, Ord)
+
+instance Show Constructor where
+  show (Constructor c) = c
+
+-- | Extracting constructors from actions.
+class Constructors (act :: (* -> *) -> * -> *) where
+
+  -- | Constructor of a given action.
+  constructor :: act v a -> Constructor
+
+  -- | Total number of constructors in the action type.
+  nConstructors :: proxy act -> Int

--- a/src/Test/StateMachine/Internal/Types.hs
+++ b/src/Test/StateMachine/Internal/Types.hs
@@ -28,19 +28,13 @@ module Test.StateMachine.Internal.Types
   , Internal(..)
   ) where
 
-import           Data.List
-                   (intercalate)
 import           Data.Typeable
-                   (Typeable, cast)
+                   (Typeable)
 import           Text.Read
-                   (Lexeme(Ident), lexP, lift, parens, prec, readPrec,
-                   step)
-import           Text.Show
-                   (showList)
+                   (Lexeme(Ident), lexP, parens, prec, readPrec, step)
 
 import           Test.StateMachine.Types
                    (Untyped(Untyped))
-import           Test.StateMachine.Types.HFunctor
 import           Test.StateMachine.Types.References
 
 ------------------------------------------------------------------------

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -43,7 +43,7 @@ module Test.StateMachine.Types
   where
 
 import           Data.Functor.Classes
-                   (Ord1, Show1, showsPrec1)
+                   (Ord1)
 import           Data.Typeable
                    (Typeable)
 import           Test.QuickCheck

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE Rank2Types           #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -42,7 +43,7 @@ module Test.StateMachine.Types
   where
 
 import           Data.Functor.Classes
-                   (Ord1)
+                   (Ord1, Show1, showsPrec1)
 import           Data.Typeable
                    (Typeable)
 import           Test.QuickCheck

--- a/src/Test/StateMachine/Types/References.hs
+++ b/src/Test/StateMachine/Types/References.hs
@@ -35,8 +35,6 @@ import           Data.Functor.Classes
                    showsPrec1)
 import           Data.Typeable
                    (Typeable)
-import           Text.Read
-                   (readPrec)
 
 import           Test.StateMachine.Types.HFunctor
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
 resolver: lts-8.13
 packages:
   - '.'
-extra-deps: []
+extra-deps:
+  - 'quickcheck-with-counterexamples-1.0'
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
- Add variants of properties which return counterexamples, so we don't need to read them from strings anymore.
- Add a type class to recognize constructors. A TH script to write the instances is TODO.
- Fix `Show` instances. TODO: This makes traces pretty noisy, looking like `Write (Reference (Symbolic (Var 0))) 0` instead of `Write (Var 0) 0`. But instead of hijacking `Show`, it seems better to specify a custom printer of actions separately, via an explicit parameter or a different type class.
- Remove `Read` instances in examples and unused imports.

Fixes #157