### PR TITLE
Update travis script to not build the library in install phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 install:
 # Build dependencies
 - stack --install-ghc test --only-dependencies
-- stack --stack-yaml=example/stack.yaml test --only-dependencies
+- stack --stack-yaml=example/stack.yaml test --only-snapshot
 
 script:
 # Build the package, its tests, and its docs and run the tests

--- a/src/Test/StateMachine/Internal/Parallel.hs
+++ b/src/Test/StateMachine/Internal/Parallel.hs
@@ -217,7 +217,7 @@ linearise transition postcondition model0 = go . unHistory
   go es = anyP (step model0) (linearTree es)
 
   step :: model Concrete -> Tree (Operation act err) -> Property
-  step model (Node (Operation act _ (Fail _)                     _) roses) =
+  step model (Node (Operation _ _ (Fail _)                     _) roses) =
     anyP' (step model) roses
   step model (Node (Operation act _ (Ok (resp@(Concrete resp'))) _) roses) =
     postcondition model act resp' .&&.


### PR DESCRIPTION
Previously, the library was getting built in the install phase, so the `--pedantic` flag for warning-free code only applied to examples.

Would you also like hlint to be added to CI?