### PR TITLE
Add upper bound on QuickCheck dependency.

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -55,7 +55,7 @@ library
         monad-control >=1.0.2.2,
         mtl >=2.2.1,
         pretty-show,
-        QuickCheck >=2.9.2,
+        QuickCheck >=2.9.2 && <2.12,
         split >=0.2.3.3,
         stm >=2.4.4.1,
         tree-diff,

--- a/src/Test/StateMachine/Types/History.hs
+++ b/src/Test/StateMachine/Types/History.hs
@@ -66,7 +66,8 @@ deriving instance (Show (cmd Concrete), Show (resp Concrete)) =>
 takeInvocations :: History' cmd resp -> [(Pid, cmd Concrete)]
 takeInvocations []                               = []
 takeInvocations ((pid, Invocation cmd _) : hist) = (pid, cmd) : takeInvocations hist
-takeInvocations ((_,   Response     _)   : _)    = []
+takeInvocations ((_,   Response _)       : _)    = []
+takeInvocations ((_,   Exception _)      : _)    = []
 
 findResponse :: Pid -> History' cmd resp -> [(resp Concrete, History' cmd resp)]
 findResponse _   []                                         = []


### PR DESCRIPTION
From 2.12 the arguments of cover have been swapped.