### PR TITLE
Replace MonadBaseControl IO with MonadUnliftIO

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -50,16 +50,14 @@ library
         base >=4.9 && <5,
         containers >=0.5.7.1,
         exceptions >=0.8.3,
-        lifted-async >=0.9.3,
         matrix >=0.3.5.0,
-        monad-control >=1.0.2.2,
         mtl >=2.2.1,
         pretty-show,
         QuickCheck >=2.9.2,
         split >=0.2.3.3,
-        stm >=2.4.4.1,
         tree-diff >=0.0.2,
-        vector >=0.12.0.1
+        vector >=0.12.0.1,
+        unliftio >=0.2.7.0
   default-language:    Haskell2010
 
 test-suite quickcheck-state-machine-test
@@ -74,9 +72,7 @@ test-suite quickcheck-state-machine-test
                        filelock,
                        filepath,
                        http-client,
-                       lifted-async >=0.9.3,
                        matrix >=0.3.5.0,
-                       monad-control >=1.0.2.2,
                        monad-logger,
                        mtl,
                        network,
@@ -92,7 +88,6 @@ test-suite quickcheck-state-machine-test
                        servant,
                        servant-client,
                        servant-server,
-                       stm,
                        strict,
                        string-conversions,
                        tasty,
@@ -102,7 +97,8 @@ test-suite quickcheck-state-machine-test
                        tree-diff,
                        vector >=0.12.0.1,
                        wai,
-                       warp
+                       warp,
+                       unliftio
 
   other-modules:       CircularBuffer,
                        CrudWebserverDb,

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -61,20 +61,14 @@ module CrudWebserverDb
 
 import           Control.Concurrent
                    (newEmptyMVar, putMVar, takeMVar, threadDelay)
-import           Control.Concurrent.Async.Lifted
-                   (Async, async, cancel, waitEither)
 import           Control.Exception
                    (IOException, bracket)
 import           Control.Exception
                    (catch)
-import           Control.Monad.IO.Class
-                   (liftIO)
 import           Control.Monad.Logger
                    (NoLoggingT, runNoLoggingT)
 import           Control.Monad.Reader
                    (ReaderT, ask, runReaderT)
-import           Control.Monad.Trans.Control
-                   (MonadBaseControl, liftBaseWith)
 import           Control.Monad.Trans.Resource
                    (ResourceT)
 import qualified Data.ByteString.Char8           as BS
@@ -133,6 +127,8 @@ import           Test.QuickCheck.Instances
                    ()
 import           Test.QuickCheck.Monadic
                    (monadic)
+import           UnliftIO
+                   (MonadIO, Async, liftIO, async, cancel, waitEither)
 
 import           Test.StateMachine
 import qualified Test.StateMachine.Types.Rank2   as Rank2
@@ -449,9 +445,9 @@ burl :: Warp.Port -> BaseUrl
 burl port = BaseUrl Http "localhost" port ""
 
 setup
-  :: MonadBaseControl IO m
+  :: MonadIO m
   => Bug -> (String -> ConnectionString) -> Warp.Port -> m (String, Async ())
-setup bug conn port = liftBaseWith $ \_ -> do
+setup bug conn port = liftIO $ do
   (pid, dbIp) <- setupDb
   signal   <- newEmptyMVar
   aServer  <- async (runServer bug (conn dbIp) port (putMVar signal ()))

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -24,10 +24,6 @@ module Echo
   )
   where
 
-import           Control.Concurrent.STM
-                   (atomically)
-import           Control.Concurrent.STM.TVar
-                   (TVar, newTVarIO, readTVar, writeTVar)
 import           Data.TreeDiff
                    (ToExpr)
 import           GHC.Generics
@@ -37,6 +33,8 @@ import           Test.QuickCheck
                    (Gen, Property, arbitrary, oneof, (===))
 import           Test.QuickCheck.Monadic
                    (monadicIO)
+import           UnliftIO
+                   (TVar, newTVarIO, readTVar, writeTVar, atomically)
 
 import           Test.StateMachine
 import           Test.StateMachine.Types


### PR DESCRIPTION
* Replace `MonadBaseControl IO m` with `MonadUnliftIO m`. Reasoning: see the  documentation for [`unliftio`](http://hackage.haskell.org/package/unliftio).

* Replace `liftBaseWith (const ..)` with `liftIO ..`. This means that these  `MonadBaseControl IO m` constraints can be simplified to `MonadIO m`  constraints.

* Remove manual `liftIO`s where possible by using lifted functions from  `unliftio`.

* Replace the uses of lifted functions from `lifted-async` by the  corresponding lifted variants from `unliftio`.

* Replace the uses of functions from `stm` by the corresponding lifted  variants from `unliftio`.