### PR TITLE
Add a stopcondition to StateMachine

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -104,6 +104,7 @@ test-suite quickcheck-state-machine-test
                        CrudWebserverDb,
                        DieHard,
                        Echo,
+                       ErrorEncountered,
                        MemoryReference,
                        TicketDispenser
 

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -68,6 +68,7 @@ data StateMachine model cmd m resp = StateMachine
   , shrinker       :: cmd Symbolic -> [cmd Symbolic]
   , semantics      :: cmd Concrete -> m (resp Concrete)
   , mock           :: model Symbolic -> cmd Symbolic -> GenSym (resp Symbolic)
+  , stopcondition  :: model Symbolic -> Bool
   }
 
 data Command cmd = Command !(cmd Symbolic) !(Set Var)

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -282,6 +282,7 @@ sm :: Version -> Bugs -> StateMachine Model Action IO Response
 sm version bugs = StateMachine
   initModel transition (precondition bugs) postcondition
   Nothing (generator version) Nothing shrinker (semantics bugs) mock
+  (const False)
 
 -- | Property parameterized by spec version and bugs.
 prepropcircularBuffer :: Version -> Bugs -> Property

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -347,7 +347,7 @@ mock (Model m) act = case act of
 
 sm :: StateMachine Model Action (ReaderT ClientEnv IO) Response
 sm = StateMachine initModel transitions preconditions postconditions
-       Nothing generator Nothing shrinker semantics mock
+       Nothing generator Nothing shrinker semantics mock (const False)
 
 ------------------------------------------------------------------------
 -- * Sequential property

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -154,7 +154,7 @@ mock _ _ = return Done
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transitions preconditions postconditions
-       Nothing generator Nothing shrinker semantics mock
+       Nothing generator Nothing shrinker semantics mock (const False)
 
 prop_dieHard :: Property
 prop_dieHard = forAllCommands sm Nothing $ \cmds -> monadicIO $ do

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -97,6 +97,7 @@ echoSM env = StateMachine
     , shrinker = mShrinker
     , semantics = mSemantics
     , mock = mMock
+    , stopcondition = const False
     }
     where
       mTransitions :: Model r -> Action r -> Response r -> Model r

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+
+module ErrorEncountered
+  ( prop_error_sequential
+  , prop_error_parallel
+  )
+  where
+
+import           Data.Functor.Classes
+                   (Eq1)
+import           Data.IORef
+                   (IORef, newIORef, readIORef,
+                   writeIORef)
+import           Data.TreeDiff
+                   (ToExpr)
+import           GHC.Generics
+                   (Generic, Generic1)
+import           Prelude                       hiding
+                   (elem)
+import           Test.QuickCheck
+                   (Gen, Property, arbitrary, elements, frequency,
+                   shrink, (===))
+import           Test.QuickCheck.Monadic
+                   (monadicIO)
+
+import           Test.StateMachine
+import           Test.StateMachine.Types
+                   (Reference(..), Symbolic(..))
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.StateMachine.Z
+
+-----------------------------------------------------------------------------
+
+-- Similar to MemoryReference, but with the possibilty of a 'Write' failing,
+-- in which case the test should stop.
+--
+-- Writing a negative value will result in the 'WriteFailed' response. This
+-- will transition the model into the 'ErrorEncountered' state, resulting in
+-- the termination of the test. This is achieved by the 'stopcondition' of
+-- 'StateMachine', which returns 'True' when the model is in the
+-- 'ErrorEncountered' state.
+
+-----------------------------------------------------------------------------
+
+data Command r
+  = Create
+  | Read  (Reference (Opaque (IORef Int)) r)
+  | Write (Reference (Opaque (IORef Int)) r) Int
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+
+deriving instance Show (Command Symbolic)
+deriving instance Show (Command Concrete)
+
+data Response r
+  = Created (Reference (Opaque (IORef Int)) r)
+  | ReadValue Int
+  | Written
+  | WriteFailed
+  deriving (Generic1, Rank2.Foldable)
+
+deriving instance Show (Response Symbolic)
+deriving instance Show (Response Concrete)
+
+data Model r
+  = Model [(Reference (Opaque (IORef Int)) r, Int)]
+  | ErrorEncountered
+  deriving (Generic, Show)
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model empty
+
+transition :: Eq1 r => Model r -> Command r -> Response r -> Model r
+transition ErrorEncountered _  _    = ErrorEncountered
+transition m@(Model model) cmd resp = case (cmd, resp) of
+  (Create, Created ref)        -> Model ((ref, 0) : model)
+  (Read _, ReadValue _)        -> m
+  (Write ref x, Written)       -> Model (update ref x model)
+  (Write _   _, WriteFailed)   -> ErrorEncountered
+  _                            -> error "transition: impossible."
+
+update :: Eq a => a -> b -> [(a, b)] -> [(a, b)]
+update ref i m = (ref, i) : filter ((/= ref) . fst) m
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition ErrorEncountered _ = Bot
+precondition (Model m) cmd = case cmd of
+  Create        -> Top
+  Read  ref     -> ref `elem` domain m
+  Write ref _   -> ref `elem` domain m
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition (Model m) cmd resp = case (cmd, resp) of
+  (Create,        Created ref) -> m' ! ref .== 0 .// "Create"
+    where
+      m' = case transition (Model m) cmd resp of
+          Model m1         -> m1
+          ErrorEncountered -> error "postcondition ErrorEncountered"
+          -- A Create cannot lead to ErrorEncountered
+  (Read ref,      ReadValue v)  -> v .== m ! ref .// "Read"
+  (Write _ref _x, Written)      -> Top
+  (Write _ref  x, WriteFailed)
+      | x < 0                   -> Top
+  _                             -> Bot
+postcondition ErrorEncountered _ _ = Bot
+
+semantics :: Command Concrete -> IO (Response Concrete)
+semantics cmd = case cmd of
+  Create          -> Created   <$> (reference . Opaque <$> newIORef 0)
+  Read ref        -> ReadValue <$> readIORef  (opaque ref)
+  Write ref i
+      | i >= 0    -> Written   <$  writeIORef (opaque ref) i
+      | otherwise -> pure       $  WriteFailed
+
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock ErrorEncountered _ = error "mock ErrorEncountered"
+mock (Model m) cmd = case cmd of
+  Create          -> Created   <$> genSym
+  Read ref        -> ReadValue <$> pure (m ! ref)
+  Write _ i
+      | i >= 0    -> pure Written
+      | otherwise -> pure WriteFailed
+
+generator :: Model Symbolic -> Gen (Command Symbolic)
+generator (Model model) = frequency
+  [ (1, pure Create)
+  , (4, Read  <$> elements (domain model))
+  , (4, Write <$> elements (domain model) <*> arbitrary)
+  ]
+generator ErrorEncountered = error "generator ErrorEncountered"
+
+shrinker :: Command Symbolic -> [Command Symbolic]
+shrinker (Write ref i) = [ Write ref i' | i' <- shrink i ]
+shrinker _             = []
+
+stopcondition :: Model r -> Bool
+stopcondition ErrorEncountered = True
+stopcondition _                = False
+
+sm :: StateMachine Model Command IO Response
+sm = StateMachine initModel transition precondition postcondition
+         Nothing generator Nothing shrinker semantics mock stopcondition
+
+prop_error_sequential :: Property
+prop_error_sequential = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
+  (hist, _model, res) <- runCommands sm cmds
+  prettyCommands sm hist (checkCommandNames cmds (res === Ok))
+
+prop_error_parallel :: Property
+prop_error_parallel = forAllParallelCommands sm $ \cmds -> monadicIO $ do
+  prettyParallelCommands cmds =<< runParallelCommands sm cmds

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -158,6 +158,7 @@ shrinker _             = []
 sm :: Bug -> StateMachine Model Command IO Response
 sm bug = StateMachine initModel transition precondition postcondition
            Nothing generator Nothing shrinker (semantics bug) mock
+           (const False)
 
 prop_sequential :: Bug -> Property
 prop_sequential bug = forAllCommands sm' Nothing $ \cmds -> monadicIO $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,6 +24,7 @@ import           CircularBuffer
 import qualified CrudWebserverDb       as WS
 import           DieHard
 import           Echo
+import           ErrorEncountered
 import           MemoryReference
 import           TicketDispenser
 
@@ -40,6 +41,10 @@ tests docker0 = testGroup "Tests"
       , testProperty "Race bug sequential"                (prop_sequential Race)
       , testProperty "Race bug parallel"   (expectFailure (prop_parallel   Race))
       , testProperty "Precondition failed" prop_precondition
+      ]
+  , testGroup "ErrorEncountered"
+      [ testProperty "sequential" prop_error_sequential
+      , testProperty "parallel"   prop_error_parallel
       ]
   , testGroup "Crud webserver"
       [ webServer docker0 WS.None  8800 "No bug"                       WS.prop_crudWebserverDb

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -193,6 +193,7 @@ sm :: SharedExclusive -> DbLock -> StateMachine Model Action IO Response
 sm se files = StateMachine
   initModel transitions preconditions postconditions
   Nothing generator Nothing shrinker (semantics se files) mock
+  (const False)
 
 -- Sequentially the model is consistent (even though the lock is
 -- shared).


### PR DESCRIPTION
This stopcondition stops the test in progress. Imagine that an (expected) error is thrown during the tests and the tested system is now in a state where it can no longer process new commands. In that case we should be able to gracefully stop the test in progress.