### PR TITLE
Fix important bug in shrinking

### DIFF
--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -70,7 +70,7 @@ data StateMachine model cmd m resp = StateMachine
   , mock           :: model Symbolic -> cmd Symbolic -> GenSym (resp Symbolic)
   }
 
-data Command cmd = Command !(cmd Symbolic) !(Set Var)
+data Command cmd = Command !(cmd Symbolic) ![Var]
 
 deriving instance Show (cmd Symbolic) => Show (Command cmd)
 

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -24,7 +24,6 @@ import           Data.Functor.Classes
 import           Data.IORef
                    (IORef, atomicModifyIORef', newIORef, readIORef,
                    writeIORef)
-import qualified Data.Set                      as Set
 import           Data.TreeDiff
                    (ToExpr)
 import           GHC.Generics
@@ -180,4 +179,4 @@ prop_precondition = once $ monadicIO $ do
     where
       sm'  = sm None
       cmds = Commands
-        [ Types.Command (Read (Reference (Symbolic (Var 0)))) Set.empty ]
+        [ Types.Command (Read (Reference (Symbolic (Var 0)))) [] ]


### PR DESCRIPTION
Consider shrinking a set of commands such as

```haskell
Commands [
    Command cmd1           (S.fromList [Var 0])
  , Command cmd2           (S.fromList [Var 1])
  , Command (cmd3 (Var 1)) (S.fromList [])
  ]
```

Shrinking is basically a call to QuickCheck's `shrinkList` followed by a
validation step, the core of which is implemented in `validCommands`.
`validCommands` executes each command, checking preconditions, and checking
which variables are in scope, and (effectively) renaming variables. For
example, given the shrink candidate

```haskell
Commands [
    -- first command deleted
    Command cmd2           (S.fromList [Var 1])
  , Command (cmd3 (Var 1)) (S.fromList [])
  ]
```

`validCommands` will reexecute `cmd2`, find all is well, construct

```haskell
    Command cmd2           (S.fromList [Var 0]) -- variable 0 instead of 1
```

However, when it then gets to `cmd3`, it finds that `Var 1` is not in scope,
and regard the shrink candidate as invalid. This however is not correct:
`cmd3` refers to the result of `cmd2`, which is still in the shrunk program!
Conversely, if the original program was

```haskell
Commands [
    Command cmd1           (S.fromList [Var 0])
  , Command cmd2           (S.fromList [Var 1])
  , Command (cmd3 (Var 0)) (S.fromList [])
  ]
```

instead, with `cmd3` referring to the output of the _first_ command, then the
same shrink candidate

```haskell
Commands [
    -- first command deleted
    Command cmd2           (S.fromList [Var 1])
  , Command (cmd3 (Var 0)) (S.fromList [])
  ]
```

_should_ now be rejected (after all, `cmd3` refers to the output of `cmd1`,
which has been deleted), but instead may not be, and result in the "validated"
program

```haskell
Commands [
    -- first command deleted
    Command cmd2           (S.fromList [Var 0])
  , Command (cmd3 (Var 0)) (S.fromList [])
  ]
```

where `cmd3` suddenly referse to `cmd2` instead.

Instead of merely keeping track of the scope, therefore, we need to keep track
of this remapping of variables, constructing the validated program

```haskell
Commands [
    -- first command deleted
    Command cmd2           (S.fromList [Var 0])
  , Command (cmd3 (Var 0)) (S.fromList [])
  ]
```

for the first example, and rejecting the second example.

This is implemented in this patch. The essence of the patch is the logic in
`go` in `validCommands`. It has a few small knock-on effect:

* In order to be able to translate commands we need `cmd` to be
  `Rank2.Traversable` rather than merely `Rank2.Foldable`
* It is important that we precise about the _order_ of the variables returned
  by commands; therefore using a set rather than a list in `Command` is not
  correct.
* The internal state of `validCommands` now uses a `Map` rather than a `Set`,
  which requires a few trivial updates to other functions that are defined
  in terms of `validCommands`.