### PR TITLE
Allow the generation of commands to stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ postcondition (Model m) cmd resp = case (cmd, resp) of
 Next we have to explain how to generate and shrink actions.
 
 ```haskell
-generator :: Model Symbolic -> Gen (Command Symbolic)
-generator (Model model) = frequency
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator (Model model) = Just $ frequency
   [ (1, pure Create)
   , (4, Read  <$> elements (domain model))
   , (4, Write <$> elements (domain model) <*> arbitrary)
@@ -155,6 +155,9 @@ shrinker :: Command Symbolic -> [Command Symbolic]
 shrinker (Write ref i) = [ Write ref i' | i' <- shrink i ]
 shrinker _             = []
 ```
+
+To stop the generation of new commands, e.g., when the model has reached a
+terminal or error state, let `generator` return `Nothing`.
 
 Finally, we show how to mock responses given a model.
 

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -104,6 +104,7 @@ test-suite quickcheck-state-machine-test
                        CrudWebserverDb,
                        DieHard,
                        Echo,
+                       ErrorEncountered,
                        MemoryReference,
                        TicketDispenser
 

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -136,19 +136,22 @@ generateCommandsState StateMachine { precondition, generator, transition
     go 0    _       cmds = return (reverse cmds)
     go size counter cmds = do
       (model, mprevious) <- get
-      mnext <- lift $ commandFrequency (generator model) distribution mprevious
-                  `suchThatOneOf` (boolean . precondition model)
-      case mnext of
-        Nothing   -> error $ concat
-                       [ "A deadlock occured while generating commands.\n"
-                       , "No pre-condition holds in the following model:\n"
-                       , ppShow model
-                       -- XXX: show trace of commands generated so far?
-                       ]
-        Just next -> do
-          let (resp, counter') = runGenSym (mock model next) counter
-          put (transition model next resp, Just next)
-          go (size - 1) counter' (Command next (getUsedVars resp) : cmds)
+      case generator model of
+          Nothing -> return (reverse cmds)
+          Just cmd -> do
+            mnext <- lift $ commandFrequency cmd distribution mprevious
+                        `suchThatOneOf` (boolean . precondition model)
+            case mnext of
+              Nothing   -> error $ concat
+                             [ "A deadlock occured while generating commands.\n"
+                             , "No pre-condition holds in the following model:\n"
+                             , ppShow model
+                             -- XXX: show trace of commands generated so far?
+                             ]
+              Just next -> do
+                let (resp, counter') = runGenSym (mock model next) counter
+                put (transition model next resp, Just next)
+                go (size - 1) counter' (Command next (getUsedVars resp) : cmds)
 
 commandFrequency :: forall cmd. (Generic1 cmd, GConName1 (Rep1 cmd))
                  => Gen (cmd Symbolic) -> Maybe (Matrix Int) -> Maybe (cmd Symbolic)

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -63,7 +63,7 @@ data StateMachine model cmd m resp = StateMachine
   , precondition   :: model Symbolic -> cmd Symbolic -> Logic
   , postcondition  :: model Concrete -> cmd Concrete -> resp Concrete -> Logic
   , invariant      :: Maybe (model Concrete -> Logic)
-  , generator      :: model Symbolic -> Gen (cmd Symbolic)
+  , generator      :: model Symbolic -> Maybe (Gen (cmd Symbolic))
   , distribution   :: Maybe (Matrix Int)
   , shrinker       :: cmd Symbolic -> [cmd Symbolic]
   , semantics      :: cmd Concrete -> m (resp Concrete)

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -242,9 +242,9 @@ genNew = do
   Positive n <- arbitrary
   return (New n)
 
-generator :: Version -> Model Symbolic -> Gen (Action Symbolic)
-generator _       (Model m) | null m = genNew
-generator version (Model m)          = frequency $
+generator :: Version -> Model Symbolic -> Maybe (Gen (Action Symbolic))
+generator _       (Model m) | null m = Just $ genNew
+generator version (Model m)          = Just $ frequency $
   [ (1, genNew)
   , (4, Put <$> arbitrary <*> (fst <$> elements m))
   , (4, Get <$> (fst <$> elements m))

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -307,8 +307,8 @@ postconditions _         _              _              = error "postconditions"
 ------------------------------------------------------------------------
 -- * How to generate and shrink programs.
 
-generator :: Model Symbolic -> Gen (Action Symbolic)
-generator (Model m) = frequency
+generator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
+generator (Model m) = Just $ frequency
   [ (1, PostUser   <$> arbitrary)
   , (3, GetUser    <$> elements (map fst m))
   , (4, IncAgeUser <$> elements (map fst m))

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -119,8 +119,8 @@ postconditions s c r = bigJug (transitions s c r) ./= 4
 -- The generator of actions is simple, with equal distribution pick an
 -- action.
 
-generator :: Model Symbolic -> Gen (Command Symbolic)
-generator _ = oneof
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator _ = Just $ oneof
   [ return FillBig
   , return FillSmall
   , return EmptyBig

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -122,8 +122,8 @@ echoSM env = StateMachine
       mPostconditions (Buf _)   Echo   _         = Bot
 
       -- | Generator for symbolic actions.
-      mGenerator :: Model Symbolic -> Gen (Action Symbolic)
-      mGenerator _ =  oneof
+      mGenerator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
+      mGenerator _ =  Just $ oneof
           [ In <$> arbitrary
           , return Echo
           ]

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+
+module ErrorEncountered
+  ( prop_error_sequential
+  , prop_error_parallel
+  )
+  where
+
+import           Data.Functor.Classes
+                   (Eq1)
+import           Data.IORef
+                   (IORef, newIORef, readIORef,
+                   writeIORef)
+import           Data.TreeDiff
+                   (ToExpr)
+import           GHC.Generics
+                   (Generic, Generic1)
+import           Prelude                       hiding
+                   (elem)
+import           Test.QuickCheck
+                   (Gen, Property, arbitrary, elements, frequency,
+                   shrink, (===))
+import           Test.QuickCheck.Monadic
+                   (monadicIO)
+
+import           Test.StateMachine
+import           Test.StateMachine.Types
+                   (Reference(..), Symbolic(..))
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.StateMachine.Z
+
+-----------------------------------------------------------------------------
+
+-- Similar to MemoryReference, but with the possibilty of a 'Write' failing,
+-- in which case the test should stop.
+--
+-- Writing a negative value will result in the 'WriteFailed' response. This
+-- will transition the model into the 'ErrorEncountered' state, resulting in
+-- the termination of the test. This is achieved by letting the 'generator'
+-- return 'Nothing' when the model is in the 'ErrorEncountered' state.
+
+-----------------------------------------------------------------------------
+
+data Command r
+  = Create
+  | Read  (Reference (Opaque (IORef Int)) r)
+  | Write (Reference (Opaque (IORef Int)) r) Int
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+
+deriving instance Show (Command Symbolic)
+deriving instance Show (Command Concrete)
+
+data Response r
+  = Created (Reference (Opaque (IORef Int)) r)
+  | ReadValue Int
+  | Written
+  | WriteFailed
+  deriving (Generic1, Rank2.Foldable)
+
+deriving instance Show (Response Symbolic)
+deriving instance Show (Response Concrete)
+
+data Model r
+  = Model [(Reference (Opaque (IORef Int)) r, Int)]
+  | ErrorEncountered
+  deriving (Generic, Show)
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model empty
+
+transition :: Eq1 r => Model r -> Command r -> Response r -> Model r
+transition ErrorEncountered _  _    = ErrorEncountered
+transition m@(Model model) cmd resp = case (cmd, resp) of
+  (Create, Created ref)        -> Model ((ref, 0) : model)
+  (Read _, ReadValue _)        -> m
+  (Write ref x, Written)       -> Model (update ref x model)
+  (Write _   _, WriteFailed)   -> ErrorEncountered
+  _                            -> error "transition: impossible."
+
+update :: Eq a => a -> b -> [(a, b)] -> [(a, b)]
+update ref i m = (ref, i) : filter ((/= ref) . fst) m
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition ErrorEncountered _ = Bot
+precondition (Model m) cmd = case cmd of
+  Create        -> Top
+  Read  ref     -> ref `elem` domain m
+  Write ref _   -> ref `elem` domain m
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition (Model m) cmd resp = case (cmd, resp) of
+  (Create,        Created ref) -> m' ! ref .== 0 .// "Create"
+    where
+      m' = case transition (Model m) cmd resp of
+          Model m1         -> m1
+          ErrorEncountered -> error "postcondition ErrorEncountered"
+          -- A Create cannot lead to ErrorEncountered
+  (Read ref,      ReadValue v)  -> v .== m ! ref .// "Read"
+  (Write _ref _x, Written)      -> Top
+  (Write _ref  x, WriteFailed)
+      | x < 0                   -> Top
+  _                             -> Bot
+postcondition ErrorEncountered _ _ = Bot
+
+semantics :: Command Concrete -> IO (Response Concrete)
+semantics cmd = case cmd of
+  Create          -> Created   <$> (reference . Opaque <$> newIORef 0)
+  Read ref        -> ReadValue <$> readIORef  (opaque ref)
+  Write ref i
+      | i >= 0    -> Written   <$  writeIORef (opaque ref) i
+      | otherwise -> pure       $  WriteFailed
+
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock ErrorEncountered _ = error "mock ErrorEncountered"
+mock (Model m) cmd = case cmd of
+  Create          -> Created   <$> genSym
+  Read ref        -> ReadValue <$> pure (m ! ref)
+  Write _ i
+      | i >= 0    -> pure Written
+      | otherwise -> pure WriteFailed
+
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator (Model model) = Just $ frequency
+  [ (1, pure Create)
+  , (4, Read  <$> elements (domain model))
+  , (4, Write <$> elements (domain model) <*> arbitrary)
+  ]
+generator ErrorEncountered = Nothing
+
+shrinker :: Command Symbolic -> [Command Symbolic]
+shrinker (Write ref i) = [ Write ref i' | i' <- shrink i ]
+shrinker _             = []
+
+sm :: StateMachine Model Command IO Response
+sm = StateMachine initModel transition precondition postcondition
+         Nothing generator Nothing shrinker semantics mock
+
+prop_error_sequential :: Property
+prop_error_sequential = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
+  (hist, _model, res) <- runCommands sm cmds
+  prettyCommands sm hist (checkCommandNames cmds (res === Ok))
+
+prop_error_parallel :: Property
+prop_error_parallel = forAllParallelCommands sm $ \cmds -> monadicIO $ do
+  prettyParallelCommands cmds =<< runParallelCommands sm cmds

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -143,8 +143,8 @@ mock (Model m) cmd = case cmd of
   Write _ _   -> pure Written
   Increment _ -> pure Incremented
 
-generator :: Model Symbolic -> Gen (Command Symbolic)
-generator (Model model) = frequency
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator (Model model) = Just $ frequency
   [ (1, pure Create)
   , (4, Read  <$> elements (domain model))
   , (4, Write <$> elements (domain model) <*> arbitrary)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -24,6 +24,7 @@ import           CircularBuffer
 import qualified CrudWebserverDb       as WS
 import           DieHard
 import           Echo
+import           ErrorEncountered
 import           MemoryReference
 import           TicketDispenser
 
@@ -40,6 +41,10 @@ tests docker0 = testGroup "Tests"
       , testProperty "Race bug sequential"                (prop_sequential Race)
       , testProperty "Race bug parallel"   (expectFailure (prop_parallel   Race))
       , testProperty "Precondition failed" prop_precondition
+      ]
+  , testGroup "ErrorEncountered"
+      [ testProperty "sequential" prop_error_sequential
+      , testProperty "parallel"   prop_error_parallel
       ]
   , testGroup "Crud webserver"
       [ webServer docker0 WS.None  8800 "No bug"                       WS.prop_crudWebserverDb

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -110,8 +110,8 @@ postconditions _         _          _             = error "postconditions"
 -- With stateful generation we ensure that the dispenser is reset before
 -- use.
 
-generator :: Model Symbolic -> Gen (Action Symbolic)
-generator _ = frequency
+generator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
+generator _ = Just $ frequency
   [ (1, pure Reset)
   , (4, pure TakeTicket)
   ]


### PR DESCRIPTION
Imagine that an (expected) error is thrown during the tests and the tested
system is now in a state where it can no longer process new commands. In that
case we should be able to gracefully stop the test in progress.

We achieve this by letting the generator return `Nothing` to indicate that no
more commands should be generated.

This supersedes #253 and #254.