### PR TITLE
Prepare for v0.5.0 release. [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-#### 0.4.4 (???)
+#### 0.5.0 (2019-1-4)
 
-  * Check if the pre-condition holds before executing an action.
+  The first and third item in the below list might break things, have a look at
+  the diffs of the PRs on how to fix your code (feel free to open an issue if it
+  isn't clear).
+
+  * Allow the user to explicitly stop the generation of commands (PR #256);
+  * Fix shrinking bug (PR #255);
+  * Replace MonadBaseControl IO with MonadUnliftIO (PR #252);
+  * Check if the pre-condition holds before executing an action (PR #251).
 
 #### 0.4.3 (2018-12-7)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2017-2018 Stevan Andjelkovic, Daniel Gustafsson, Jacob Stanley,
-                        Xia Li-yao, Robert Danitz
+Copyright (c) 2017-2019 Stevan Andjelkovic, Daniel Gustafsson, Jacob Stanley,
+                        Xia Li-yao, Robert Danitz, Thomas Winant, Edsko de Vries
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -430,6 +430,15 @@ repo, `cd` into it, fire up `stack ghci --test`, load the different examples,
 e.g. `:l test/CrudWebserverDb.hs`, and run the different properties
 interactively.
 
+### Real world examples
+
+More examples from the "real world":
+
+  * Adjoint's implementation of the Raft consensus algorithm, contains state
+    machine
+    [tests](https://github.com/adjoint-io/raft/blob/master/test/QuickCheckStateMachine.hs)
+    combined with fault injection (node and network failures).
+
 ### How to contribute
 
 The `quickcheck-state-machine` library is still very experimental.
@@ -439,9 +448,9 @@ we can improve it on the issue tracker!
 
 ### See also
 
-  * The QuickCheck
-    bugtrack [issue](https://github.com/nick8325/quickcheck/issues/139) -- where
-    the initial discussion about how how to add state machine based testing to
+  * The QuickCheck bugtrack
+    [issue](https://github.com/nick8325/quickcheck/issues/139) -- where the
+    initial discussion about how to add state machine based testing to
     QuickCheck started;
 
   * *Finding Race Conditions in Erlang with QuickCheck and

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -1,5 +1,5 @@
 name:                quickcheck-state-machine
-version:             0.4.3
+version:             0.5.0
 synopsis:            Test monadic programs using state machine based models
 description:         See README at <https://github.com/advancedtelematic/quickcheck-state-machine#readme>
 homepage:            https://github.com/advancedtelematic/quickcheck-state-machine#readme
@@ -8,7 +8,7 @@ license-file:        LICENSE
 author:              Stevan Andjelkovic
 maintainer:          Stevan Andjelkovic <stevan.andjelkovic@here.com>
 copyright:           Copyright (C) 2017-2018, ATS Advanced Telematic Systems GmbH;
-                                   2018, HERE Europe B.V.
+                                   2018-2019, HERE Europe B.V.
 category:            Testing
 build-type:          Simple
 extra-source-files:  README.md


### PR DESCRIPTION
* Update the changelog.
* Bump copyright year and add new contributors to license file.
* Bump version and copyright year in cabal file.
* Fix typo and start list of real world examples in readme.