### PR TITLE
Generalize GConName

### DIFF
--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -42,7 +42,7 @@ module Test.StateMachine
   , Reason(..)
   , GenSym
   , genSym
-  , GConName1(..)
+  , CommandNames(..)
 
   , module Test.StateMachine.Logic
 

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -42,6 +42,7 @@ module Test.StateMachine
   , Reason(..)
   , GenSym
   , genSym
+  , GConName1(..)
 
   , module Test.StateMachine.Logic
 
@@ -49,6 +50,7 @@ module Test.StateMachine
 
 import           Prelude
                    ()
+import           Test.StateMachine.ConstructorName
 import           Test.StateMachine.Logic
 import           Test.StateMachine.Parallel
 import           Test.StateMachine.Sequential

--- a/src/Test/StateMachine/ConstructorName.hs
+++ b/src/Test/StateMachine/ConstructorName.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Test.StateMachine.ConstructorName
-  ( GConName(..)
-  , GConName1(..)
+  ( CommandNames(..)
+  , commandName
   )
   where
 
@@ -22,70 +22,68 @@ import           GHC.Generics
 import           Prelude
 
 import           Test.StateMachine.Types
-                   (Command(..), Reference, Symbolic)
+                   (Command(..))
 
 ------------------------------------------------------------------------
 
-class GConName a where
-  gconName  :: a -> String
-  gconNames :: Proxy a -> [String]
+-- | The names of all possible commands
+--
+-- This is used for things like tagging, coverage checking, etc.
+class CommandNames (cmd :: k -> *) where
+  -- | Name of this particular command
+  cmdName  :: cmd r -> String
 
-class GConName1 f where
-  gconName1  :: f a -> String
-  gconNames1 :: Proxy (f a) -> [String]
+  -- | Name of all possible commands
+  cmdNames :: Proxy (cmd r) -> [String]
 
-  default gconName1 :: (Generic1 f, GConName1 (Rep1 f)) => f a -> String
-  gconName1 = gconName1 . from1
+  default cmdName :: (Generic1 cmd, CommandNames (Rep1 cmd)) => cmd r -> String
+  cmdName = cmdName . from1
 
-  default gconNames1 :: forall a. GConName1 (Rep1 f) => Proxy (f a) -> [String]
-  gconNames1 _ = gconNames1 (Proxy @(Rep1 f a))
+  default cmdNames :: forall r. CommandNames (Rep1 cmd) => Proxy (cmd r) -> [String]
+  cmdNames _ = cmdNames (Proxy @(Rep1 cmd r))
 
-instance GConName1 U1 where
-  gconName1  _ = ""
-  gconNames1 _ = []
+instance CommandNames U1 where
+  cmdName  _ = ""
+  cmdNames _ = []
 
-instance GConName1 (K1 i c) where
-  gconName1  _ = ""
-  gconNames1 _ = []
+instance CommandNames (K1 i c) where
+  cmdName  _ = ""
+  cmdNames _ = []
 
-instance Constructor c => GConName1 (M1 C c f) where
-  gconName1                            = conName
-  gconNames1 (_ :: Proxy (M1 C c f p)) = [ conName @c undefined ] -- Can we do
+instance Constructor c => CommandNames (M1 C c f) where
+  cmdName                            = conName
+  cmdNames (_ :: Proxy (M1 C c f p)) = [ conName @c undefined ] -- Can we do
                                                                   -- better
                                                                   -- here?
 
-instance GConName1 f => GConName1 (M1 D c f) where
-  gconName1                            = gconName1  . unM1
-  gconNames1 (_ :: Proxy (M1 D c f p)) = gconNames1 (Proxy :: Proxy (f p))
+instance CommandNames f => CommandNames (M1 D c f) where
+  cmdName                            = cmdName  . unM1
+  cmdNames (_ :: Proxy (M1 D c f p)) = cmdNames (Proxy :: Proxy (f p))
 
-instance GConName1 f => GConName1 (M1 S c f) where
-  gconName1                            = gconName1  . unM1
-  gconNames1 (_ :: Proxy (M1 S c f p)) = gconNames1 (Proxy :: Proxy (f p))
+instance CommandNames f => CommandNames (M1 S c f) where
+  cmdName                            = cmdName  . unM1
+  cmdNames (_ :: Proxy (M1 S c f p)) = cmdNames (Proxy :: Proxy (f p))
 
-instance (GConName1 f, GConName1 g) => GConName1 (f :+: g) where
-  gconName1 (L1 x) = gconName1 x
-  gconName1 (R1 y) = gconName1 y
+instance (CommandNames f, CommandNames g) => CommandNames (f :+: g) where
+  cmdName (L1 x) = cmdName x
+  cmdName (R1 y) = cmdName y
 
-  gconNames1 (_ :: Proxy ((f :+: g) a)) =
-    gconNames1 (Proxy :: Proxy (f a)) ++
-    gconNames1 (Proxy :: Proxy (g a))
+  cmdNames (_ :: Proxy ((f :+: g) a)) =
+    cmdNames (Proxy :: Proxy (f a)) ++
+    cmdNames (Proxy :: Proxy (g a))
 
-instance (GConName1 f, GConName1 g) => GConName1 (f :*: g) where
-  gconName1  (x :*: y)                  = gconName1 x ++ gconName1 y
-  gconNames1 (_ :: Proxy ((f :*: g) a)) =
-    gconNames1 (Proxy :: Proxy (f a)) ++
-    gconNames1 (Proxy :: Proxy (g a))
+instance (CommandNames f, CommandNames g) => CommandNames (f :*: g) where
+  cmdName  (x :*: y)                  = cmdName x ++ cmdName y
+  cmdNames (_ :: Proxy ((f :*: g) a)) =
+    cmdNames (Proxy :: Proxy (f a)) ++
+    cmdNames (Proxy :: Proxy (g a))
 
-instance GConName1 f => GConName1 (Rec1 f) where
-  gconName1                          = gconName1  . unRec1
-  gconNames1 (_ :: Proxy (Rec1 f p)) = gconNames1 (Proxy :: Proxy (f p))
+instance CommandNames f => CommandNames (Rec1 f) where
+  cmdName                          = cmdName  . unRec1
+  cmdNames (_ :: Proxy (Rec1 f p)) = cmdNames (Proxy :: Proxy (f p))
 
 ------------------------------------------------------------------------
 
-instance GConName1 (Reference a) where
-  gconName1  _ = ""
-  gconNames1 _ = []
-
-instance GConName1 cmd => GConName (Command cmd) where
-  gconName  (Command cmd _) = gconName1  cmd
-  gconNames _               = gconNames1 (Proxy :: Proxy (cmd Symbolic))
+-- | Convenience wrapper for 'Command'
+commandName :: CommandNames cmd => Command cmd -> String
+commandName (Command cmd _) = cmdName cmd

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -81,7 +81,7 @@ import           Test.StateMachine.Utils
 
 forAllParallelCommands :: Testable prop
                        => (Show (cmd Symbolic), Show (model Symbolic))
-                       => GConName1 cmd
+                       => CommandNames cmd
                        => (Rank2.Traversable cmd, Rank2.Foldable resp)
                        => StateMachine model cmd m resp
                        -> (ParallelCommands cmd -> prop)     -- ^ Predicate.
@@ -91,7 +91,7 @@ forAllParallelCommands sm =
 
 generateParallelCommands :: forall model cmd m resp
                           . (Rank2.Foldable resp, Show (model Symbolic))
-                         => GConName1 cmd
+                         => CommandNames cmd
                          => StateMachine model cmd m resp
                          -> Gen (ParallelCommands cmd)
 generateParallelCommands sm@StateMachine { initModel } = do

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -56,8 +56,6 @@ import           Data.Set
 import qualified Data.Set                          as S
 import           Data.Tree
                    (Tree(Node))
-import           GHC.Generics
-                   (Generic1, Rep1)
 import           Prelude
 import           Test.QuickCheck
                    (Gen, Property, Testable, choose, property,
@@ -83,7 +81,7 @@ import           Test.StateMachine.Utils
 
 forAllParallelCommands :: Testable prop
                        => (Show (cmd Symbolic), Show (model Symbolic))
-                       => (Generic1 cmd, GConName1 (Rep1 cmd))
+                       => GConName1 cmd
                        => (Rank2.Traversable cmd, Rank2.Foldable resp)
                        => StateMachine model cmd m resp
                        -> (ParallelCommands cmd -> prop)     -- ^ Predicate.
@@ -93,7 +91,7 @@ forAllParallelCommands sm =
 
 generateParallelCommands :: forall model cmd m resp
                           . (Rank2.Foldable resp, Show (model Symbolic))
-                         => (Generic1 cmd, GConName1 (Rep1 cmd))
+                         => GConName1 cmd
                          => StateMachine model cmd m resp
                          -> Gen (ParallelCommands cmd)
 generateParallelCommands sm@StateMachine { initModel } = do

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -50,8 +50,8 @@ import           Control.Exception
 import           Control.Monad.Catch
                    (MonadCatch, catch)
 import           Control.Monad.State
-                   (State, StateT, evalState, evalStateT, get, lift, put,
-                   runStateT)
+                   (State, StateT, evalState, evalStateT, get, lift,
+                   put, runStateT)
 import           Data.Dynamic
                    (Dynamic, toDyn)
 import           Data.Either
@@ -85,8 +85,8 @@ import qualified Text.PrettyPrint.ANSI.Leijen      as PP
 import           Text.Show.Pretty
                    (ppShow)
 import           UnliftIO
-                   (MonadIO, TChan, newTChanIO, tryReadTChan, writeTChan,
-                   atomically)
+                   (MonadIO, TChan, atomically, newTChanIO,
+                   tryReadTChan, writeTChan)
 
 import           Test.StateMachine.ConstructorName
 import           Test.StateMachine.Logic
@@ -98,7 +98,7 @@ import           Test.StateMachine.Utils
 
 forAllCommands :: Testable prop
                => (Show (cmd Symbolic), Show (model Symbolic))
-               => GConName1 cmd
+               => CommandNames cmd
                => (Rank2.Traversable cmd, Rank2.Foldable resp)
                => StateMachine model cmd m resp
                -> Maybe Int -- ^ Minimum number of commands.
@@ -108,7 +108,7 @@ forAllCommands sm mnum =
   forAllShrinkShow (generateCommands sm mnum) (shrinkCommands sm) ppShow
 
 generateCommands :: (Rank2.Foldable resp, Show (model Symbolic))
-                 => GConName1 cmd
+                 => CommandNames cmd
                  => StateMachine model cmd m resp
                  -> Maybe Int -- ^ Minimum number of commands.
                  -> Gen (Commands cmd)
@@ -117,7 +117,7 @@ generateCommands sm@StateMachine { initModel } mnum =
 
 generateCommandsState :: forall model cmd m resp. Rank2.Foldable resp
                       => Show (model Symbolic)
-                      => GConName1 cmd
+                      => CommandNames cmd
                       => StateMachine model cmd m resp
                       -> Counter
                       -> Maybe Int -- ^ Minimum number of commands.
@@ -149,27 +149,27 @@ generateCommandsState StateMachine { precondition, generator, transition
                 put (transition model next resp, Just next)
                 go (size - 1) counter' (Command next (getUsedVars resp) : cmds)
 
-commandFrequency :: forall cmd. GConName1 cmd
+commandFrequency :: forall cmd. CommandNames cmd
                  => Gen (cmd Symbolic) -> Maybe (Matrix Int) -> Maybe (cmd Symbolic)
                  -> [(Int, Gen (cmd Symbolic))]
 commandFrequency gen Nothing             _          = [ (1, gen) ]
 commandFrequency gen (Just distribution) mprevious  =
-  [ (freq, gen `suchThat` ((== con) . gconName1)) | (freq, con) <- weights ]
+  [ (freq, gen `suchThat` ((== con) . cmdName)) | (freq, con) <- weights ]
     where
       idx = case mprevious of
               Nothing       -> 1
               Just previous ->
                 let
-                  con = gconName1 previous
+                  con = cmdName previous
                   err = "genetateCommandState: no command: " <> con
                 in
                   fromMaybe (error err) ((+ 2) <$>
-                    elemIndex con (gconNames1 (Proxy :: Proxy (cmd Symbolic))))
+                    elemIndex con (cmdNames (Proxy :: Proxy (cmd Symbolic))))
       row     = V.toList (getRow idx distribution)
-      weights = zip row (gconNames1 (Proxy :: Proxy (cmd Symbolic)))
+      weights = zip row (cmdNames (Proxy :: Proxy (cmd Symbolic)))
 
 measureFrequency :: (Rank2.Foldable resp, Show (model Symbolic))
-                 => GConName1 cmd
+                 => CommandNames cmd
                  => StateMachine model cmd m resp
                  -> Maybe Int -- ^ Minimum number of commands.
                  -> Int       -- ^ Maximum number of commands.
@@ -178,16 +178,16 @@ measureFrequency sm min0 size = do
   cmds <- generate (sequence [ resize n (generateCommands sm min0) | n <- [0, 2..size] ])
   return (M.unions (map calculateFrequency cmds))
 
-calculateFrequency :: GConName1 cmd
+calculateFrequency :: CommandNames cmd
                    => Commands cmd -> Map (String, Maybe String) Int
 calculateFrequency = go M.empty . unCommands
   where
     go m [] = m
     go m [cmd]
-      = M.insertWith (\_ old -> old + 1) (gconName cmd, Nothing) 1 m
+      = M.insertWith (\_ old -> old + 1) (commandName cmd, Nothing) 1 m
     go m (cmd1 : cmd2 : cmds)
-      = go (M.insertWith (\_ old -> old + 1) (gconName cmd1,
-                                              Just (gconName cmd2)) 1 m) cmds
+      = go (M.insertWith (\_ old -> old + 1) (commandName cmd1,
+                                              Just (commandName cmd2)) 1 m) cmds
 
 getUsedVars :: Rank2.Foldable f => f Symbolic -> [Var]
 getUsedVars = Rank2.foldMap (\(Symbolic v) -> [v])
@@ -383,35 +383,35 @@ prettyCommands sm hist prop = prettyPrintHistory sm hist `whenFailM` prop
 
 -- | Print distribution of commands and fail if some commands have not
 --   been executed.
-checkCommandNames :: forall cmd. GConName1 cmd
+checkCommandNames :: forall cmd. CommandNames cmd
                   => Commands cmd -> Property -> Property
 checkCommandNames cmds
   = collect names
   . oldCover (length names == numOfConstructors) 1 "coverage"
   where
     names             = commandNames cmds
-    numOfConstructors = length (gconNames1 (Proxy :: Proxy (cmd Symbolic)))
+    numOfConstructors = length (cmdNames (Proxy :: Proxy (cmd Symbolic)))
 
-commandNames :: forall cmd. GConName1 cmd
+commandNames :: forall cmd. CommandNames cmd
              => Commands cmd -> [(String, Int)]
 commandNames = M.toList . foldl go M.empty . unCommands
   where
     go :: Map String Int -> Command cmd -> Map String Int
-    go ih cmd = M.insertWith (+) (gconName cmd) 1 ih
+    go ih cmd = M.insertWith (+) (commandName cmd) 1 ih
 
-commandNamesInOrder :: forall cmd. GConName1 cmd
+commandNamesInOrder :: forall cmd. CommandNames cmd
                     => Commands cmd -> [String]
 commandNamesInOrder = reverse . foldl go [] . unCommands
   where
     go :: [String] -> Command cmd -> [String]
-    go ih cmd = gconName cmd : ih
+    go ih cmd = commandName cmd : ih
 
 
-transitionMatrix :: forall cmd. GConName1 cmd
+transitionMatrix :: forall cmd. CommandNames cmd
                  => Proxy (cmd Symbolic)
                  -> (String -> String -> Int) -> Matrix Int
 transitionMatrix _ f =
-  let cons = gconNames1 (Proxy :: Proxy (cmd Symbolic))
+  let cons = cmdNames (Proxy :: Proxy (cmd Symbolic))
       n    = length cons
       m    = succ n
   in matrix m n $ \case

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -150,7 +150,7 @@ data Action (r :: * -> *)
 
     -- | Get the number of elements in the buffer.
   | Len (Reference (Opaque Buffer) r)
-  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
+  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
 
 data Response (r :: * -> *)
   = NewR (Reference (Opaque Buffer) r)

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -150,7 +150,7 @@ data Action (r :: * -> *)
 
     -- | Get the number of elements in the buffer.
   | Len (Reference (Opaque Buffer) r)
-  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
 
 data Response (r :: * -> *)
   = NewR (Reference (Opaque Buffer) r)

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -71,7 +71,7 @@ import           Control.Monad.Reader
                    (ReaderT, ask, runReaderT)
 import           Control.Monad.Trans.Resource
                    (ResourceT)
-import qualified Data.ByteString.Char8           as BS
+import qualified Data.ByteString.Char8         as BS
 import           Data.Char
                    (isPrint)
 import           Data.Functor.Classes
@@ -86,7 +86,7 @@ import           Data.String.Conversions
                    (cs)
 import           Data.Text
                    (Text)
-import qualified Data.Text                       as T
+import qualified Data.Text                     as T
 import           Data.TreeDiff
                    (Expr(App), ToExpr, toExpr)
 import           Database.Persist.Postgresql
@@ -103,8 +103,8 @@ import           Network
                    (PortID(PortNumber), connectTo)
 import           Network.HTTP.Client
                    (Manager, defaultManagerSettings, newManager)
-import qualified Network.Wai.Handler.Warp        as Warp
-import           Prelude                         hiding
+import qualified Network.Wai.Handler.Warp      as Warp
+import           Prelude                       hiding
                    (elem)
 import qualified Prelude
 import           Servant
@@ -128,10 +128,10 @@ import           Test.QuickCheck.Instances
 import           Test.QuickCheck.Monadic
                    (monadic)
 import           UnliftIO
-                   (MonadIO, Async, liftIO, async, cancel, waitEither)
+                   (Async, MonadIO, async, cancel, liftIO, waitEither)
 
 import           Test.StateMachine
-import qualified Test.StateMachine.Types.Rank2   as Rank2
+import qualified Test.StateMachine.Types.Rank2 as Rank2
 
 ------------------------------------------------------------------------
 -- * User datatype
@@ -243,7 +243,7 @@ data Action (r :: * -> *)
 instance Rank2.Functor     Action where
 instance Rank2.Foldable    Action where
 instance Rank2.Traversable Action where
-instance GConName1         Action where
+instance CommandNames      Action where
 
 data Response (r :: * -> *)
   = PostedUser (Reference (Key User) r)

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -243,6 +243,7 @@ data Action (r :: * -> *)
 instance Rank2.Functor     Action where
 instance Rank2.Foldable    Action where
 instance Rank2.Traversable Action where
+instance GConName1         Action where
 
 data Response (r :: * -> *)
   = PostedUser (Reference (Key User) r)

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -58,7 +58,7 @@ data Command (r :: * -> *)
   | SmallIntoBig -- Pour the contents of the 3-liter jug
                  -- into 5-liter jug.
   | BigIntoSmall
-  deriving (Eq, Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
+  deriving (Eq, Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
 
 data Response (r :: * -> *) = Done
   deriving (Show, Generic1, Rank2.Foldable)

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -58,7 +58,7 @@ data Command (r :: * -> *)
   | SmallIntoBig -- Pour the contents of the 3-liter jug
                  -- into 5-liter jug.
   | BigIntoSmall
-  deriving (Eq, Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+  deriving (Eq, Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
 
 data Response (r :: * -> *) = Done
   deriving (Show, Generic1, Rank2.Foldable)

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -34,7 +34,7 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
                    (monadicIO)
 import           UnliftIO
-                   (TVar, newTVarIO, readTVar, writeTVar, atomically)
+                   (TVar, atomically, newTVarIO, readTVar, writeTVar)
 
 import           Test.StateMachine
 import           Test.StateMachine.Types
@@ -165,7 +165,7 @@ data Action (r :: * -> *)
       In String
       -- | Request a string output.
     | Echo
-  deriving (Show, Generic1, Rank2.Foldable, Rank2.Traversable, Rank2.Functor, GConName1)
+  deriving (Show, Generic1, Rank2.Foldable, Rank2.Traversable, Rank2.Functor, CommandNames)
 
 -- | The system gives a single type of output response, containing a string
 -- with the input previously received.

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -165,7 +165,7 @@ data Action (r :: * -> *)
       In String
       -- | Request a string output.
     | Echo
-  deriving (Show, Generic1, Rank2.Foldable, Rank2.Traversable, Rank2.Functor)
+  deriving (Show, Generic1, Rank2.Foldable, Rank2.Traversable, Rank2.Functor, GConName1)
 
 -- | The system gives a single type of output response, containing a string
 -- with the input previously received.

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module ErrorEncountered
   ( prop_error_sequential
@@ -13,8 +13,7 @@ module ErrorEncountered
 import           Data.Functor.Classes
                    (Eq1)
 import           Data.IORef
-                   (IORef, newIORef, readIORef,
-                   writeIORef)
+                   (IORef, newIORef, readIORef, writeIORef)
 import           Data.TreeDiff
                    (ToExpr)
 import           GHC.Generics
@@ -49,7 +48,7 @@ data Command r
   = Create
   | Read  (Reference (Opaque (IORef Int)) r)
   | Write (Reference (Opaque (IORef Int)) r) Int
-  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
 
 deriving instance Show (Command Symbolic)
 deriving instance Show (Command Concrete)
@@ -78,11 +77,11 @@ initModel = Model empty
 transition :: Eq1 r => Model r -> Command r -> Response r -> Model r
 transition ErrorEncountered _  _    = ErrorEncountered
 transition m@(Model model) cmd resp = case (cmd, resp) of
-  (Create, Created ref)        -> Model ((ref, 0) : model)
-  (Read _, ReadValue _)        -> m
-  (Write ref x, Written)       -> Model (update ref x model)
-  (Write _   _, WriteFailed)   -> ErrorEncountered
-  _                            -> error "transition: impossible."
+  (Create, Created ref)      -> Model ((ref, 0) : model)
+  (Read _, ReadValue _)      -> m
+  (Write ref x, Written)     -> Model (update ref x model)
+  (Write _   _, WriteFailed) -> ErrorEncountered
+  _                          -> error "transition: impossible."
 
 update :: Eq a => a -> b -> [(a, b)] -> [(a, b)]
 update ref i m = (ref, i) : filter ((/= ref) . fst) m
@@ -90,9 +89,9 @@ update ref i m = (ref, i) : filter ((/= ref) . fst) m
 precondition :: Model Symbolic -> Command Symbolic -> Logic
 precondition ErrorEncountered _ = Bot
 precondition (Model m) cmd = case cmd of
-  Create        -> Top
-  Read  ref     -> ref `elem` domain m
-  Write ref _   -> ref `elem` domain m
+  Create      -> Top
+  Read  ref   -> ref `elem` domain m
+  Write ref _ -> ref `elem` domain m
 
 postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
 postcondition (Model m) cmd resp = case (cmd, resp) of

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -49,7 +49,7 @@ data Command r
   = Create
   | Read  (Reference (Opaque (IORef Int)) r)
   | Write (Reference (Opaque (IORef Int)) r) Int
-  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
 
 deriving instance Show (Command Symbolic)
 deriving instance Show (Command Concrete)

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -53,7 +53,7 @@ data Command r
   | Read  (Reference (Opaque (IORef Int)) r)
   | Write (Reference (Opaque (IORef Int)) r) Int
   | Increment (Reference (Opaque (IORef Int)) r)
-  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
 
 deriving instance Show (Command Symbolic)
 deriving instance Show (Command Concrete)

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -53,7 +53,7 @@ data Command r
   | Read  (Reference (Opaque (IORef Int)) r)
   | Write (Reference (Opaque (IORef Int)) r) Int
   | Increment (Reference (Opaque (IORef Int)) r)
-  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
 
 deriving instance Show (Command Symbolic)
 deriving instance Show (Command Concrete)

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -68,7 +68,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 data Action (r :: * -> *)
   = TakeTicket
   | Reset
-  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
+  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
 
 data Response (r :: * -> *)
   = GotTicket Int

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -68,7 +68,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 data Action (r :: * -> *)
   = TakeTicket
   | Reset
-  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable)
+  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
 
 data Response (r :: * -> *)
   = GotTicket Int


### PR DESCRIPTION
@stevana , first of all, let me apologize for submitting another PR so soon after your release. As I am continuing to work on my example and getting very detailed about shrinking, I realized that there is another problem with the lib that makes it impossible for me to apply some of the techniques I've been using. The good news is that this is a minor change only; the bad news is that technically speaking it _is_ an API breaking change :/ 

Many top-level functions had constraints such as

```haskell
Generic1 cmd, GConName1 (Rep1 cmd)
```

This is however problematic when using commands for which `Generic1` instances
are difficult are impossible to derive or define. It is also somewhat
unidiomatic Haskell: typically we don't require `Generic1` (or `Generic`), and
then some function on the generic representation; instead we introduce a
special type class for what we want, and then provide _default_ implementations
that use generics. In this patch I do precisely this. It actually doesn't
change very much: the `GConName1` class changes to

```haskell
class GConName1 f where
  gconName1  :: f a -> String
  gconNames1 :: Proxy (f a) -> [String]

  default gconName1 :: (Generic1 f, GConName1 (Rep1 f)) => f a -> String
  gconName1 = gconName1 . from1

  default gconNames1 :: forall a. GConName1 (Rep1 f) => Proxy (f a) -> [String]
  gconNames1 _ = gconNames1 (Proxy @(Rep1 f a))
```

Notice how the translation to the generic representation is now done in the
class definition rather than in call sites; those call sites therefore change
to have constraints

```haskell
GConName1 cmd
```

instead, and don't need to worry about the translation to the generic
representation anymore. Example code does not become any more difficult, we just
need to define one more class, any `DeriveAnyClass` does the job; just as one
example, here is the one from the ticket dispenser example:

```haskell
data Action (r :: * -> *)
  = TakeTicket
  | Reset
  deriving (Show, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, GConName1)
```