### PR TITLE
Generalize to N threads

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -98,6 +98,7 @@ test-suite quickcheck-state-machine-test
                        servant,
                        servant-client,
                        servant-server,
+                       split,
                        strict,
                        string-conversions,
                        tasty,

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -31,8 +31,12 @@ module Test.StateMachine
 
   -- * Parallel property combinators
   , forAllParallelCommands
+  , forAllNParallelCommands
+  , runNParallelCommands
   , runParallelCommands
+  , runNParallelCommandsNTimes
   , runParallelCommandsNTimes
+  , prettyNParallelCommands
   , prettyParallelCommands
 
     -- * Types

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -19,21 +19,27 @@
 -----------------------------------------------------------------------------
 
 module Test.StateMachine.Parallel
-  ( forAllParallelCommands
+  ( forAllNParallelCommands
+  , forAllParallelCommands
+  , generateNParallelCommands
   , generateParallelCommands
+  , shrinkNParallelCommands
   , shrinkParallelCommands
+  , shrinkAndValidateNParallel
   , shrinkAndValidateParallel
+  , shrinkCommands'
+  , runNParallelCommands
   , runParallelCommands
+  , runNParallelCommandsNTimes
   , runParallelCommandsNTimes
   , executeParallelCommands
   , linearise
   , toBoxDrawings
+  , prettyNParallelCommands
   , prettyParallelCommands
   , advanceModel
   ) where
 
-import           Control.Arrow
-                   ((***))
 import           Control.Monad
                    (foldM, replicateM)
 import           Control.Monad.Catch
@@ -43,8 +49,10 @@ import           Control.Monad.State.Strict
 import           Data.Bifunctor
                    (bimap)
 import           Data.List
-                   (partition, permutations)
+                   (find, partition, permutations)
 import qualified Data.Map.Strict               as Map
+import           Data.Maybe
+                   (fromMaybe)
 import           Data.Monoid
                    ((<>))
 import           Data.Set
@@ -62,7 +70,8 @@ import           Text.PrettyPrint.ANSI.Leijen
 import           Text.Show.Pretty
                    (ppShow)
 import           UnliftIO
-                   (MonadIO, MonadUnliftIO, concurrently, newTChanIO)
+                   (MonadIO, MonadUnliftIO, concurrently,
+                   forConcurrently, newTChanIO)
 
 import           Test.StateMachine.BoxDrawer
 import           Test.StateMachine.Logic
@@ -81,6 +90,18 @@ forAllParallelCommands :: Testable prop
                        -> Property
 forAllParallelCommands sm =
   forAllShrinkShow (generateParallelCommands sm) (shrinkParallelCommands sm) ppShow
+
+
+forAllNParallelCommands :: Testable prop
+                        => (Show (cmd Symbolic), Show (resp Symbolic), Show (model Symbolic))
+                        => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                        => StateMachine model cmd m resp
+                        -> Int                                      -- ^ Number of threads
+                        -> (NParallelCommands cmd resp -> prop)     -- ^ Predicate.
+                        -> Property
+forAllNParallelCommands sm np =
+  forAllShrinkShow (generateNParallelCommands sm np) (shrinkNParallelCommands sm) ppShow
+
 
 -- | Generate parallel commands.
 --
@@ -142,24 +163,66 @@ generateParallelCommands sm@StateMachine { initModel } = do
                                (Pair (Commands safe1) (Commands safe2) : acc)
                                rest
           where
-            (safe, rest)   = spanSafe model [] cmds
+            (safe, rest)   = spanSafe sm model [] cmds
             (safe1, safe2) = splitAt (length safe `div` 2) safe
 
-        suffixLength = 5
+-- Split the list of commands in two such that the first half is a
+-- list of commands for which the preconditions of all commands hold
+-- for permutation of the list, i.e. it is parallel safe. The other
+-- half is the remainder of the input list.
+spanSafe :: StateMachine model cmd m resp
+         -> model Symbolic -> [Command cmd resp] -> [Command cmd resp]
+         -> ([Command cmd resp], [Command cmd resp])
+spanSafe _ _     safe []           = (reverse safe, [])
+spanSafe sm model safe (cmd : cmds)
+    | length safe <= 5
+  , parallelSafe sm model (Commands (cmd : safe))
+  = spanSafe sm model (cmd : safe) cmds
+  | otherwise
+  = (reverse safe, cmd : cmds)
 
-        -- Split the list of commands in two such that the first half is a
-        -- list of commands for which the preconditions of all commands hold
-        -- for permutation of the list, i.e. it is parallel safe. The other
-        -- half is the remainder of the input list.
-        spanSafe :: model Symbolic -> [Command cmd resp] -> [Command cmd resp]
-                 -> ([Command cmd resp], [Command cmd resp])
-        spanSafe _     safe []           = (reverse safe, [])
-        spanSafe model safe (cmd : cmds)
-          | length safe <= suffixLength
-          , parallelSafe sm model (Commands (cmd : safe))
-          = spanSafe model (cmd : safe) cmds
-          | otherwise
-          = (reverse safe, cmd : cmds)
+-- Generate Parallel commands. The length of each suffix, indicates how many thread can
+-- concurrently execute the commands safely.
+generateNParallelCommands :: forall model cmd m resp. Rank2.Foldable resp
+                          => Show (model Symbolic)
+                          => (Show (cmd Symbolic), Show (resp Symbolic))
+                          => StateMachine model cmd m resp
+                          -> Int
+                          -> Gen (NParallelCommands cmd resp)
+generateNParallelCommands sm@StateMachine { initModel } np =
+  if np <= 0 then error "number of threads must be positive" else do
+  Commands cmds      <- generateCommands sm Nothing
+  prefixLength       <- sized (\k -> choose (0, k `div` 3))
+  let (prefix, rest) =  bimap Commands Commands (splitAt prefixLength cmds)
+  return (ParallelCommands prefix
+            (makeSuffixes (advanceModel sm initModel prefix) rest))
+  where
+    makeSuffixes :: model Symbolic -> Commands cmd resp -> [[(Commands cmd resp)]]
+    makeSuffixes model0 = go model0 [] . unCommands
+      where
+        go :: model Symbolic
+           -> [[(Commands cmd resp)]]
+           -> [(Command cmd resp)]
+           -> [[(Commands cmd resp)]]
+        go _     acc []   = reverse acc
+        go model acc cmds = go (advanceModel sm model (Commands safe))
+                               (safes : acc)
+                               rest
+          where
+            (safe, rest)   = spanSafe sm model [] cmds
+            safes = Commands <$> chunksOf np (length safe `div` np) safe
+
+        -- Split the list in n sublists, whose concat is the initial list.
+        -- We try to keep the length of each sublist len.
+        --
+        -- It is important that we miss no elements here or else executeCommands may fail, because
+        -- of missing references. It is also important that the final list has the correct length
+        -- n, or else there will be different number of threads than the user specified.
+        chunksOf :: Int -> Int -> [a] -> [[a]]
+        chunksOf 1 _ xs = [xs]
+        chunksOf n len xs = as : chunksOf (n-1) len bs
+            where (as, bs) = splitAt len xs
+
 
 -- | A list of commands is parallel safe if the pre-conditions for all commands
 --   hold in all permutations of the list.
@@ -212,9 +275,6 @@ shrinkParallelCommands sm (ParallelCommands prefix suffixes)
                                   (if shrunk then DontShrink else MustShrink)
                                   cmds
 
-    shrinkCommands' :: Commands cmd resp -> [Shrunk (Commands cmd resp)]
-    shrinkCommands' = map (fmap Commands) . shrinkListS' . unCommands
-
     shrinkSuffixes :: [(Commands cmd resp, Commands cmd resp)]
                    -> [Shrunk [(Commands cmd resp, Commands cmd resp)]]
     shrinkSuffixes = shrinkListS (shrinkPairS' shrinkCommands')
@@ -230,20 +290,45 @@ shrinkParallelCommands sm (ParallelCommands prefix suffixes)
                                                     unCommands (proj2 suffix))
         ]
 
-    -- >    pickOneReturnRest []     == []
-    -- >    pickOneReturnRest [1]    == [ (1,[]) ]
-    -- >    pickOneReturnRest [1..3] == [ (1,[2,3]), (2,[1,3]), (3,[1,2]) ]
-    pickOneReturnRest :: [a] -> [(a, [a])]
-    pickOneReturnRest []       = []
-    pickOneReturnRest (x : xs) = (x, xs) : map (id *** (x :)) (pickOneReturnRest xs)
+-- | Shrink a parallel program in a pre-condition and scope respecting
+--   way.
+shrinkNParallelCommands
+  :: forall cmd model m resp. Rank2.Traversable cmd
+  => Rank2.Foldable resp
+  => StateMachine model cmd m resp
+  -> (NParallelCommands cmd resp -> [NParallelCommands cmd resp])
+shrinkNParallelCommands sm (ParallelCommands prefix suffixes)
+  = concatMap go
+      [ Shrunk s (ParallelCommands prefix' suffixes')
+      | Shrunk s (prefix', suffixes') <- shrinkPairS shrinkCommands' shrinkSuffixes
+                                                     (prefix, suffixes)
+      ]
+      ++
+      shrinkMoveSuffixToPrefix
+  where
+    go :: Shrunk (NParallelCommands cmd resp) -> [NParallelCommands cmd resp]
+    go (Shrunk shrunk cmds) =
+      shrinkAndValidateNParallel sm
+                                       (if shrunk then DontShrink else MustShrink)
+                                       cmds
 
-    -- >    pickOneReturnRest2 ([], []) == []
-    -- >    pickOneReturnRest2 ([1,2], [3,4])
-    -- > == [ (1,([2],[3,4])), (2,([1],[3,4])), (3,([1,2],[4])), (4,([1,2],[3])) ]
-    pickOneReturnRest2 :: ([a], [a]) -> [(a, ([a],[a]))]
-    pickOneReturnRest2 (xs, ys) =
-      map (id *** flip (,) ys) (pickOneReturnRest xs) ++
-      map (id ***      (,) xs) (pickOneReturnRest ys)
+    shrinkSuffixes :: [[Commands cmd resp]]
+                   -> [Shrunk [[Commands cmd resp]]]
+    shrinkSuffixes = shrinkListS (shrinkListS'' shrinkCommands')
+
+    -- Moving a command from a suffix to the prefix preserves validity
+    shrinkMoveSuffixToPrefix :: [NParallelCommands cmd resp]
+    shrinkMoveSuffixToPrefix = case suffixes of
+      []                   -> []
+      (suffix : suffixes') ->
+        [ ParallelCommands (prefix <> Commands [prefix'])
+                           (fmap Commands suffix' : suffixes')
+        | (prefix', suffix') <- pickOneReturnRestL (unCommands <$> suffix)
+        ]
+
+-- | Shrinks Commands in a way that it has strictly less number of commands.
+shrinkCommands' :: Commands cmd resp -> [Shrunk (Commands cmd resp)]
+shrinkCommands' = map (fmap Commands) . shrinkListS' . unCommands
 
 shrinkAndValidateParallel :: forall model cmd m resp. (Rank2.Traversable cmd, Rank2.Foldable resp)
                           => StateMachine model cmd m resp
@@ -258,9 +343,6 @@ shrinkAndValidateParallel sm@StateMachine { initModel } = \shouldShrink (Paralle
       MustShrink -> concatMap (curryGo DontShrink) (shrinkAndValidate sm MustShrink env prefix)
                  ++ concatMap (curryGo MustShrink) (shrinkAndValidate sm DontShrink env prefix)
   where
-    withCounterFrom :: ValidateEnv model -> ValidateEnv model -> ValidateEnv model
-    e `withCounterFrom` e' = e { veCounter = veCounter e' }
-
     go :: Commands cmd resp          -- validated prefix
        -> ValidateEnv model          -- environment after the prefix
        -> ShouldShrink               -- should we /still/ shrink something?
@@ -279,14 +361,8 @@ shrinkAndValidateParallel sm@StateMachine { initModel } = \shouldShrink (Paralle
             ((shrinkL, shrinkR), shrinkRest) <- shrinkOpts
             (envL, l') <- shrinkAndValidate sm shrinkL  env                         l
             (envR, r') <- shrinkAndValidate sm shrinkR (env `withCounterFrom` envL) r
-            go' (Pair l' r' : acc) (combineEnv envL envR r') shrinkRest suffixes
+            go' (Pair l' r' : acc) (combineEnv sm envL envR r') shrinkRest suffixes
           where
-            combineEnv :: ValidateEnv model -> ValidateEnv model -> Commands cmd resp -> ValidateEnv model
-            combineEnv envL envR cmds = ValidateEnv {
-                  veModel   = advanceModel sm (veModel envL) cmds
-                , veScope   = Map.union (veScope envL) (veScope envR)
-                , veCounter = veCounter envR
-                }
 
             shrinkOpts :: [((ShouldShrink, ShouldShrink), ShouldShrink)]
             shrinkOpts =
@@ -295,6 +371,80 @@ shrinkAndValidateParallel sm@StateMachine { initModel } = \shouldShrink (Paralle
                   MustShrink -> [ ((MustShrink, DontShrink), DontShrink)
                                 , ((DontShrink, MustShrink), DontShrink)
                                 , ((DontShrink, DontShrink), MustShrink) ]
+
+combineEnv :: StateMachine model cmd m resp
+           -> ValidateEnv model
+           -> ValidateEnv model
+           -> Commands cmd resp
+           -> ValidateEnv model
+combineEnv sm envL envR cmds = ValidateEnv {
+      veModel   = advanceModel sm (veModel envL) cmds
+    , veScope   = Map.union (veScope envL) (veScope envR)
+    , veCounter = veCounter envR
+    }
+
+withCounterFrom :: ValidateEnv model -> ValidateEnv model -> ValidateEnv model
+withCounterFrom e e' = e { veCounter = veCounter e' }
+
+shrinkAndValidateNParallel :: forall model cmd m resp. (Rank2.Traversable cmd, Rank2.Foldable resp)
+                           => StateMachine model cmd m resp
+                           -> ShouldShrink
+                           -> NParallelCommands cmd resp
+                           -> [NParallelCommands cmd resp]
+shrinkAndValidateNParallel sm = \shouldShrink  (ParallelCommands prefix suffixes) ->
+    let env = initValidateEnv $ initModel sm
+        curryGo shouldShrink' (env', prefix') = go prefix' env' shouldShrink' suffixes in
+    case shouldShrink of
+      DontShrink -> concatMap (curryGo DontShrink) (shrinkAndValidate sm DontShrink env prefix)
+      MustShrink -> concatMap (curryGo DontShrink) (shrinkAndValidate sm MustShrink env prefix)
+                 ++ concatMap (curryGo MustShrink) (shrinkAndValidate sm DontShrink env prefix)
+  where
+
+    go :: Commands cmd resp         -- validated prefix
+       -> ValidateEnv model         -- environment after the prefix
+       -> ShouldShrink              -- should we /still/ shrink something?
+       -> [[Commands cmd resp]]     -- suffixes to validate
+       -> [NParallelCommands cmd resp]
+    go prefix' envAfterPrefix = go' [] envAfterPrefix
+      where
+        go' :: [[Commands cmd resp]] -- accumulated validated suffixes (in reverse order)
+            -> ValidateEnv model     -- environment after the validated suffixes
+            -> ShouldShrink          -- should we /still/ shrink something?
+            -> [[Commands cmd resp]] -- suffixes to validate
+            -> [NParallelCommands cmd resp]
+        go' _   _   MustShrink [] = [] -- Failed to shrink something
+        go' acc _   DontShrink [] = [ParallelCommands prefix' (reverse acc)]
+        go' acc env shouldShrink (suffix : suffixes) = do
+            (suffixWithShrinks, shrinkRest) <- shrinkOpts suffix
+            (envFinal, suffix') <- snd $ foldl f (True, [(env,[])]) suffixWithShrinks
+            go' ((reverse suffix') : acc) envFinal shrinkRest suffixes
+          where
+
+            f :: (Bool, [(ValidateEnv model, [Commands cmd resp])])
+              -> (ShouldShrink, Commands cmd resp)
+              -> (Bool, [(ValidateEnv model, [Commands cmd resp])])
+            f (firstCall, acc') (shrink, cmds) = (False, acc'')
+              where
+                    acc'' = do
+                      (envPrev, cmdsPrev) <- acc'
+                      let envUsed = if firstCall then env else env `withCounterFrom` envPrev
+                      (env', cmd') <- shrinkAndValidate sm shrink envUsed cmds
+                      let env'' = if firstCall then env' else
+                            combineEnv sm envPrev env' cmd'
+                      return (env'', cmd' : cmdsPrev)
+
+            shrinkOpts :: [a] -> [([(ShouldShrink, a)], ShouldShrink)]
+            shrinkOpts ls =
+              let len = length ls
+                  dontShrink = replicate len DontShrink
+                  shrinks = if len == 0
+                    then error "Invariant violation! A suffix should never be an empty list"
+                    else flip map [1..len] $ \n ->
+                        (replicate (n - 1) DontShrink) ++ [MustShrink] ++ (replicate (len - n) DontShrink)
+              in case shouldShrink of
+                  DontShrink -> [(zip dontShrink ls, DontShrink)]
+                  MustShrink -> fmap (\shrinkLs -> (zip shrinkLs ls, DontShrink)) shrinks
+                             ++ [(zip dontShrink ls, MustShrink)]
 
 ------------------------------------------------------------------------
 
@@ -306,6 +456,14 @@ runParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
                     -> PropertyM m [(History cmd resp, Logic)]
 runParallelCommands sm = runParallelCommandsNTimes 10 sm
 
+runNParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
+                     => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                     => (MonadCatch m, MonadUnliftIO m)
+                     => StateMachine model cmd m resp
+                     -> NParallelCommands cmd resp
+                     -> PropertyM m [(History cmd resp, Logic)]
+runNParallelCommands sm = runNParallelCommandsNTimes 10 sm
+
 runParallelCommandsNTimes :: (Show (cmd Concrete), Show (resp Concrete))
                           => (Rank2.Traversable cmd, Rank2.Foldable resp)
                           => (MonadCatch m, MonadUnliftIO m)
@@ -316,6 +474,18 @@ runParallelCommandsNTimes :: (Show (cmd Concrete), Show (resp Concrete))
 runParallelCommandsNTimes n sm cmds =
   replicateM n $ do
     (hist, _reason) <- run (executeParallelCommands sm cmds)
+    return (hist, linearise sm hist)
+
+runNParallelCommandsNTimes :: (Show (cmd Concrete), Show (resp Concrete))
+                           => (Rank2.Traversable cmd, Rank2.Foldable resp)
+                           => (MonadCatch m, MonadUnliftIO m)
+                           => Int -- ^ How many times to execute the parallel program.
+                           -> StateMachine model cmd m resp
+                           -> NParallelCommands cmd resp
+                           -> PropertyM m [(History cmd resp, Logic)]
+runNParallelCommandsNTimes n sm cmds =
+  replicateM n $ do
+    (hist, _reason) <- run (execueNParallelCommands sm cmds)
     return (hist, linearise sm hist)
 
 executeParallelCommands :: (Show (cmd Concrete), Show (resp Concrete))
@@ -353,10 +523,50 @@ executeParallelCommands sm@StateMachine{ initModel } (ParallelCommands prefix su
       return ( reason1 `combineReason` reason2
              , env1 <> env2
              )
+        where
+          combineReason :: Reason -> Reason -> Reason
+          combineReason Ok r2 = r2
+          combineReason r1 _  = r1
+
+execueNParallelCommands :: (Rank2.Traversable cmd, Show (cmd Concrete), Rank2.Foldable resp)
+                        => Show (resp Concrete)
+                        => (MonadCatch m, MonadUnliftIO m)
+                        => StateMachine model cmd m resp
+                        -> NParallelCommands cmd resp
+                        -> m (History cmd resp, Reason)
+execueNParallelCommands sm@StateMachine{ initModel } (ParallelCommands prefix suffixes) = do
+
+  hchan <- newTChanIO
+
+  (reason0, (env0, _smodel, _counter, _cmodel)) <- runStateT
+    (executeCommands sm hchan (Pid 0) True prefix)
+    (emptyEnvironment, initModel, newCounter, initModel)
+
+  if reason0 /= Ok
+  then do
+    hist <- getChanContents hchan
+    return (History hist, reason0)
+  else do
+    (reason, _) <- foldM (go hchan) (reason0, env0) suffixes
+    hist <- getChanContents hchan
+    return (History hist, reason)
+  where
+    go _ (_, env) [] = return (Ok, env)
+    go hchan (_, env) suffix = do
+      reasons <- forConcurrently (zip [1..] suffix) $ \(i, cmds) ->
+
+        -- XXX: Post-conditions not checked, so we can pass in initModel here...
+        -- It would be better if we made executeCommands take a Maybe model
+        -- instead of the boolean...
+
+        (runStateT (executeCommands sm hchan (Pid i) False cmds) (env, initModel, newCounter, initModel))
+      return ( combineReasons (fst <$> reasons)
+             , mconcat ((\(_, (env', _, _, _)) -> env') <$> reasons)
+             )
       where
-        combineReason :: Reason -> Reason -> Reason
-        combineReason Ok r2 = r2
-        combineReason r1 _  = r1
+        combineReasons :: [Reason] -> Reason
+        combineReasons ls = fromMaybe Ok (find (/= Ok) ls)
+
 
 ------------------------------------------------------------------------
 
@@ -402,13 +612,30 @@ prettyParallelCommands cmds =
       printCounterexample _hist _
         = error "prettyParallelCommands: impossible, because `boolean l` was False."
 
-      simplify :: Counterexample -> Counterexample
-      simplify (ExistsC [] [])            = BotC
-      simplify (ExistsC _ [Fst ce])       = ce
-      simplify (ExistsC x (Fst ce : ces)) = ce `EitherC` simplify (ExistsC x ces)
-      simplify (ExistsC _ (Snd ce : _))   = simplify ce
-      simplify _                          = error "simplify: impossible,\
-                                                  \ because of the structure of linearise."
+simplify :: Counterexample -> Counterexample
+simplify (ExistsC [] [])            = BotC
+simplify (ExistsC _ [Fst ce])       = ce
+simplify (ExistsC x (Fst ce : ces)) = ce `EitherC` simplify (ExistsC x ces)
+simplify (ExistsC _ (Snd ce : _))   = simplify ce
+simplify _                          = error "simplify: impossible,\
+                                            \ because of the structure of linearise."
+
+-- | Takes the output of parallel program runs and pretty prints a
+--   counterexample if any of the runs fail.
+prettyNParallelCommands :: (MonadIO m)
+                        => NParallelCommands cmd resp
+                        -> [(History cmd resp, Logic)] -- ^ Output of 'runNParallelCommands'.
+                        -> PropertyM m ()
+prettyNParallelCommands _cmds =
+  mapM_ (\(hist, l) -> printCounterexample hist (logic l) `whenFailM` property (boolean l))
+    where
+      printCounterexample _hist  (VFalse ce) = do
+        putStrLn ""
+        print (simplify ce)
+        putStrLn ""
+      printCounterexample _hist _
+        = error "prettyParallelCommands: impossible, because `boolean l` was False."
+
 
 -- | Draw an ASCII diagram of the history of a parallel program. Useful for
 --   seeing how a race condition might have occured.

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -260,7 +260,7 @@ data ShouldShrink = MustShrink | DontShrink
 --
 -- > [    -- outermost list recording all the shrink possibilities
 -- >     [A', B1', C', D', E' , F', G', H']   -- B shrunk to B1
--- >   , [A', B1', C', D', E' , F', G', H']   -- B shrunk to B2
+-- >   , [A', B2', C', D', E' , F', G', H']   -- B shrunk to B2
 -- >   , [A', B' , C', D', E1', F', G', H']   -- E shrunk to E1
 -- >   , [A', B' , C', D', E2', F', G', H']   -- E shrunk to E2
 -- >   , [A', B' , C', D', E3', F', G', H']   -- E shrunk to E3

--- a/src/Test/StateMachine/Types/GenSym.hs
+++ b/src/Test/StateMachine/Types/GenSym.hs
@@ -44,6 +44,7 @@ genSym  = GenSym $ do
   return (Reference (Symbolic (Var i)))
 
 newtype Counter = Counter Int
+  deriving Show
 
 newCounter :: Counter
 newCounter = Counter 0

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -21,6 +21,7 @@
 module Echo
   ( mkEnv
   , prop_echoOK
+  , prop_echoNParallelOK
   , prop_echoParallelOK
   )
   where
@@ -87,6 +88,14 @@ prop_echoParallelOK problem = forAllParallelCommands smUnused $ \cmds -> monadic
     let n | problem   = 2
           | otherwise = 1
     prettyParallelCommands cmds =<< runParallelCommandsNTimes n echoSM' cmds
+
+prop_echoNParallelOK :: Int -> Bool -> Property
+prop_echoNParallelOK np problem = forAllNParallelCommands smUnused np $ \cmds -> monadicIO $ do
+    env <- liftIO $ mkEnv
+    let echoSM' = echoSM env
+    let n | problem   = 2
+          | otherwise = 1
+    prettyNParallelCommands cmds =<< runNParallelCommandsNTimes n echoSM' cmds
 
 smUnused :: StateMachine Model Action IO Response
 smUnused = echoSM $ error "used env during command generation"

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -6,6 +6,7 @@
 
 module ErrorEncountered
   ( prop_error_sequential
+  , prop_error_nparallel
   , prop_error_parallel
   )
   where
@@ -147,3 +148,7 @@ prop_error_sequential = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
 prop_error_parallel :: Property
 prop_error_parallel = forAllParallelCommands sm $ \cmds -> monadicIO $ do
   prettyParallelCommands cmds =<< runParallelCommands sm cmds
+
+prop_error_nparallel :: Int -> Property
+prop_error_nparallel np = forAllNParallelCommands sm np $ \cmds -> monadicIO $ do
+  prettyNParallelCommands cmds =<< runNParallelCommands sm cmds


### PR DESCRIPTION
This pr is WIP. Related issue https://github.com/advancedtelematic/quickcheck-state-machine/issues/15
So far Parallel Commands were executed by 2 threads. In this Pr I generalize this: each suffix, instead of a Pair of `Commands` is now a list of `Commands` and each thread executes one of them.

Things TODO/future improvements:
- [x] there is a bug at shrinking, which I have to fix before merging this pr. (more below).
- [x] test more examples. So far I have only tested MemoryReference.
- [x] test the shrinker by extending shrinking properties. We now test that the execution for n=1 is equivalent to the sequential and that shrinking for n=2 is equivalent to the existing parallel.
- [ ] optimize. Even for 4 threads, execution gets very slow.  Tuning parameters like suffix length may help. Edit: some thoughts I'm working on https://github.com/advancedtelematic/quickcheck-state-machine/issues/321
- [x] generalize also the ASCII diagram of parallel commands (see `toBoxDrawings`). Edit: We decided to use dot. Maybe on some different pr? Issue created: https://github.com/advancedtelematic/quickcheck-state-machine/issues/316
- [x] ~probably there are more ways to shrink.~ Edit: that's not needed since it will increase execution time and shrinking will not anymore be equivalent for n=2.
- [x] add comments and beautyfy.
- [ ] The pr is built so that it is NOT a breaking api change. This means however that currently there are 2 versions of each function: the existing one which works on Pairs and a new one which works on Lists. As discussed in the Issue 15, I could generalize the existing functions to work on some Traversable. I believe this will be an easy generalizion once the list works properly for all tests and the bug is fixed. Edit: Some internal functions already work on Foldable or Traversable.

About the BUG (Edit: Fixed):

The bug is on shrinking, probably at `shrinkAndValidateGeneralParallel`, somewhere in the combination of environments (I have left a comment in code). The bug some times appears, when I run prop_general_parallel of MemoryReference, with 2,3 or 4 threads and a Race Bug:
```
OK (0.66s)
      +++ OK, failed as expected. (after 9 tests and 3 shrinks):
      Exception:
        executeCommands: impossible 
        Left (EnvironmentValueNotFound (Var 0))
        CallStack (from HasCallStack):
          error, called at src/Test/StateMachine/Sequential.hs:336:33 in quickcheck-state-machine-0.6.0-34jzR3JpmPESvqdQjrvbB:Test.StateMachine.Sequential
      ParallelCommands
        { prefix =
            Commands
              { unCommands =
                  [ Command Create (Created (Reference (Symbolic (Var 0)))) [ Var 0 ]
                  ]
              }
        , suffixes =
            [ []
            , [ Commands
                  { unCommands =
                      [ Command (Read (Reference (Symbolic (Var 0)))) (ReadValue 0) [] ]
                  }
              ]
            ]
        }
      *** Exception running callback: 
      executeCommands: impossible 
      Left (EnvironmentValueNotFound (Var 0))
      CallStack (from HasCallStack):
        error, called at src/Test/StateMachine/Sequential.hs:336:33 in quickcheck-state-machine-0.6.0-34jzR3JpmPESvqdQjrvbB:Test.StateMachine.Sequential
```
The test seems to succeed (or maybe fail as expected), but it fails for the wrong reason. I am not quite sure why the example above throws the `EnvironmentValueNotFound`, I need to dig a bit deeper.

(By the way these kind of false positives makes me think `expectFailure` should fail in such cases, something you mention there https://github.com/nick8325/quickcheck/issues/230)