### PR TITLE
remove ioProperty from tests

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -21,8 +21,7 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
                    (assertFailure, testCase)
 import           Test.Tasty.QuickCheck
-                   (expectFailure, ioProperty, testProperty,
-                   withMaxSuccess)
+                   (expectFailure, testProperty, withMaxSuccess)
 
 import           CircularBuffer
 import qualified CrudWebserverDb          as WS
@@ -63,10 +62,10 @@ tests docker0 = testGroup "Tests"
       , webServer docker0 WS.Race  8803 "Race bug"    (expectFailure . WS.prop_crudWebserverDbParallel)
       ]
   , testGroup "Ticket dispenser"
-      [ ticketDispenser "sequential"                   prop_ticketDispenser
-      , ticketDispenser "parallel with exclusive lock" (withMaxSuccess 30 .
+      [ testProperty "sequential"                   prop_ticketDispenser
+      , testProperty "parallel with exclusive lock" (withMaxSuccess 30
                                                         prop_ticketDispenserParallelOK)
-      , ticketDispenser "parallel with shared lock"    (expectFailure .
+      , testProperty "parallel with shared lock"    (expectFailure
                                                         prop_ticketDispenserParallelBad)
       ]
   , testGroup "Circular buffer"
@@ -82,10 +81,10 @@ tests docker0 = testGroup "Tests"
           prop_circularBuffer
       ]
   , testGroup "Echo"
-      [ testProperty "sequential"  (ioProperty (prop_echoOK <$> mkEnv))
-      , testProperty "parallel ok" (ioProperty (prop_echoParallelOK False <$> mkEnv))
+      [ testProperty "sequential" prop_echoOK
+      , testProperty "parallel ok" (prop_echoParallelOK False)
       , testProperty "parallel bad, see issue #218"
-          (expectFailure (ioProperty (prop_echoParallelOK True <$> mkEnv)))
+          (expectFailure (prop_echoParallelOK True))
       ]
   , testGroup "ProcessRegistry"
       [ testProperty "sequential" (prop_processRegistry markovGood)
@@ -112,10 +111,6 @@ tests docker0 = testGroup "Tests"
       | docker    = withResource (WS.setup bug WS.connectionString port) WS.cleanup
                      (const (testProperty test (prop port)))
       | otherwise = testCase ("No docker, skipping: " ++ test) (return ())
-
-    ticketDispenser test prop =
-      withResource setupLock cleanupLock
-        (\ioLock -> testProperty test (ioProperty (prop <$> ioLock)))
 
     assertException :: Exception e => (e -> Bool) -> IO a -> IO ()
     assertException p io = do


### PR DESCRIPTION
Related Issue https://github.com/advancedtelematic/quickcheck-state-machine/issues/240
We use the same approach at iohk, to avoid using `ioPropery` for tests which need some initialization. `forAllCommands` needs a `StateMachine`, but never uses the semantics. So these semantics don't need to be initialized. What do you think?

We can see that tests now shrink:
```
    parallel bad, see issue #218:                                  OK
      +++ OK, failed as expected. Falsifiable (after 2 tests and 2 shrinks):
      ParallelCommands
        { prefix =
            Commands
              { unCommands =
                  [ Command
                      (In
                         "M`Yk\v<v5_:rc!% aex\930410Zh\DC1\1110845z8YP\DELW=1o\v9\920537\789089\SO\"Hqn\SUBkS\417326H~p]NS\219097\250984\&1kX\SYNv\153590\125848ijH^E\227605U8@\319153)\SUBlYhri\RS\1064709\&7`\CAN\SYN\f\216950\933519\615337\73182\&0:8J]-\882234:\DC1")
                      InAck
                      []
                  ]
              }
        , suffixes = []
        }
```

```
    parallel with shared lock:                                     OK (0.70s)
      +++ OK, failed as expected. Falsifiable (after 10 tests and 2 shrinks):
      ParallelCommands
        { prefix = Commands { unCommands = [ Command Reset ResetOk [] ] }
        , suffixes =
            [ Pair
                { proj1 =
                    Commands { unCommands = [ Command TakeTicket (GotTicket 0) [] ] }
                , proj2 =
                    Commands { unCommands = [ Command TakeTicket (GotTicket 0) [] ] }
                }
            ]
        }
```