### PR TITLE
[WIP] Fix/crud example docker

### DIFF
--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -507,12 +507,12 @@ setupDb = do
           addr : _ <- getAddrInfo (Just hints) (Just ip) (Just "5432")
           sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
           (connect sock (addrAddress addr) >>
-            callProcess "docker"
+            readProcess "docker"
               [ "exec"
               , "-u", "postgres"
               , pid
               , "psql", "-U", "postgres", "-d", "postgres", "-c", "SELECT 1 + 1"
-              ] >> return sock)
+              ] "" >> return sock)
             `catch` (\(_ :: IOException) -> do
                         threadDelay 1000000
                         go (n - 1))

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -62,7 +62,7 @@ module CrudWebserverDb
 import           Control.Concurrent
                    (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import           Control.Exception
-                   (IOException, bracket, catch)
+                   (IOException, bracket, catch, onException)
 import           Control.Monad.Logger
                    (NoLoggingT, runNoLoggingT)
 import           Control.Monad.Reader
@@ -484,7 +484,7 @@ setupDb = do
     , "--format"
     , "'{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
     ] ""
-  healthyDb pid ip
+  healthyDb pid ip `onException` callProcess "docker" [ "rm", "-f", "-v", pid ]
   return (pid, ip)
   where
     trim :: String -> String
@@ -520,5 +520,5 @@ setupDb = do
 
 cleanup :: (String, Async ()) -> IO ()
 cleanup (pid, aServer) = do
-  callProcess "docker" [ "rm", "-f", pid ]
+  callProcess "docker" [ "rm", "-f", "-v", pid ]
   cancel aServer

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -498,7 +498,7 @@ setupDb = do
       close sock
       where
         go :: Int -> IO Socket
-        go 0 = error "healtyDb: db isn't healthy"
+        go 0 = error "healthyDb: db isn't healthy"
         go n = do
           let hints = defaultHints
                 { addrFlags      = [AI_NUMERICHOST , AI_NUMERICSERV]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,8 +7,6 @@ import           Control.Exception
 import           Data.List
                    (isPrefixOf)
 import           Prelude
-import           System.Environment
-                   (lookupEnv)
 import           System.Exit
                    (ExitCode(..))
 import           System.Process
@@ -131,19 +129,13 @@ tests docker0 = testGroup "Tests"
 
 main :: IO ()
 main = do
-
   -- Check if docker is avaiable.
   ec <- rawSystemNoStdout "docker" ["version"]
           `catch` (\(_ :: IOError) -> return (ExitFailure 127))
   let docker = case ec of
                  ExitSuccess   -> True
                  ExitFailure _ -> False
-
-  -- Check if we are running on CI (this environment variable is set by Travis).
-  ci <- (== Just "true") <$> lookupEnv "CONTINUOUS_INTEGRATION"
-
-  -- Only run tests involving docker when we are not on CI, as they are flaky.
-  defaultMain (tests (docker && not ci))
+  defaultMain (tests docker)
     where
       rawSystemNoStdout cmd args =
         withCreateProcess


### PR DESCRIPTION
There is a problem with example in `test/CrudWebserverDb.hs` where it will sometimes try connecting to postgres before the database is ready. This PR prevents this by adding another health check and also makes sure that docker containers and volumes are properly cleaned up afterwards.

The new health check creates some noisy output that obscures test results (that are hard to read anyway tbh), so this PR is WIP, as I hope to address this issue as well.