### PR TITLE
Depend on latest version of Quickcheck (2.13.1).

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -60,9 +60,9 @@ library
         time >=1.7,
         pretty-show >=1.6.16,
         process >=1.2.0.0,
-        QuickCheck >=2.9.2,
+        QuickCheck >=2.13.1,
         random >=1.1,
-        tree-diff >=0.0.2,
+        tree-diff >=0.0.2.1,
         unliftio >=0.2.7.0
   default-language:    Haskell2010
 
@@ -88,7 +88,7 @@ test-suite quickcheck-state-machine-test
                        persistent-template,
                        pretty-show,
                        process,
-                       QuickCheck >=2.9.2,
+                       QuickCheck,
                        quickcheck-instances,
                        quickcheck-state-machine,
                        random,

--- a/src/Test/StateMachine/Markov.hs
+++ b/src/Test/StateMachine/Markov.hs
@@ -74,8 +74,8 @@ import           System.IO
 import           System.Process
                    (callProcess)
 import           Test.QuickCheck
-                   (Gen, Property, Testable, frequency, property,
-                   quickCheck)
+                   (Gen, Property, Testable, coverTable, frequency,
+                   property, quickCheck, tabulate)
 import           Test.QuickCheck.Monadic
                    (PropertyM, run)
 import           Test.QuickCheck.Property
@@ -96,8 +96,6 @@ import           Test.StateMachine.Types.GenSym
                    (runGenSym)
 import           Test.StateMachine.Types.References
                    (Concrete, Symbolic)
-import           Test.StateMachine.Utils
-                   (newCoverTable, newTabulate)
 
 ------------------------------------------------------------------------
 
@@ -183,7 +181,7 @@ coverMarkov :: (Show state, Show cmd_, Testable prop)
 coverMarkov markov prop = foldr go (property prop) (Map.toList (unMarkov markov))
   where
     go (from, ts) ih =
-      newCoverTable (show from)
+      coverTable (show from)
         (map (\Transition{..} -> (toTransitionString command to, probability)) ts) ih
 
 toTransitionString :: (Show state, Show cmd_) => cmd_ -> state -> String
@@ -207,7 +205,7 @@ tabulateMarkov sm partition constructor cmds0 =
     tabulateTransitions ts prop = foldr go (property prop) ts
       where
         go (from, Transition {..}) ih =
-          newTabulate (show from) [ toTransitionString command to ] ih
+          tabulate (show from) [ toTransitionString command to ] ih
 
     commandsToTransitions :: StateMachine model cmd m resp
                           -> Commands cmd resp

--- a/src/Test/StateMachine/Parallel.hs
+++ b/src/Test/StateMachine/Parallel.hs
@@ -54,7 +54,7 @@ import           Data.Tree
                    (Tree(Node))
 import           Prelude
 import           Test.QuickCheck
-                   (Gen, Property, Testable, choose, property, sized)
+                   (Gen, Property, Testable, choose, property, sized, forAllShrinkShow)
 import           Test.QuickCheck.Monadic
                    (PropertyM, run)
 import           Text.PrettyPrint.ANSI.Leijen

--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -80,7 +80,7 @@ import           System.FilePath
                    ((</>))
 import           Test.QuickCheck
                    (Gen, Property, Testable, choose, collect, once,
-                   sized, whenFail)
+                   sized, whenFail, forAllShrinkShow, cover)
 import           Test.QuickCheck.Monadic
                    (PropertyM, run)
 import           Text.PrettyPrint.ANSI.Leijen
@@ -488,7 +488,7 @@ checkCommandNames :: forall cmd resp. CommandNames cmd
                   => Commands cmd resp -> Property -> Property
 checkCommandNames cmds
   = collect names
-  . oldCover (length names == numOfConstructors) 1 "coverage"
+  . cover 1 (length names == numOfConstructors) "coverage"
   where
     names             = commandNames cmds
     numOfConstructors = length (cmdNames (Proxy :: Proxy (cmd Symbolic)))

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,10 @@ extra-deps:
   - generic-data-0.3.0.0@sha256:86cac53570f45f5b1e5f54d8765d0a05f1674b3703e4dbb48a919f89c57b3cbc
   - markov-chain-usage-model-0.0.0@sha256:1afa95faeb9213c4d960a669190078b41b89169462b8edd910472980671ba8c0
   - matrix-0.3.6.1@sha256:96ab17d9a959cd5c0e9e6db5bc48069dba5f6fa17f7f4aea838d22f35e7bc047
-  - tree-diff-0.0.2@sha256:99d84e4639d8ebbd727f4223ab39b589eedeff7ed659db2f9b5b572fa33cd410
+  - QuickCheck-2.13.1@sha256:fdc6fe6c36ae05e77597d2eba22184f826f162f119e4992f8e79dede593910c5
+  - splitmix-0.0.2@sha256:e1c4d1202757d63cd4b4498d5fa600a792f2a315d2fdc6cf772f4679113c1819
+  - tree-diff-0.0.2.1@sha256:4bd07bd26091f21710288c1037124bfe19aadb5bdf3df57c8374afaa5f14fef8
+allow-newer: true
 nix:
   enable: false
   pure: false

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -60,16 +60,15 @@ import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
                    (Arbitrary(..), Gen, Property, conjoin,
-                   counterexample, elements, getNonNegative, getSmall,
-                   oneof, property, testProperty, (===))
+                   counterexample, elements, forAllShrinkShow,
+                   getNonNegative, getSmall, oneof, property,
+                   testProperty, (===))
 
 import           Test.StateMachine
 import qualified Test.StateMachine.Parallel    as QSM
 import qualified Test.StateMachine.Sequential  as QSM
 import qualified Test.StateMachine.Types       as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
-import           Test.StateMachine.Utils
-                   (forAllShrinkShow)
 
 tests :: TestTree
 tests = testGroup "Shrinking properties" [


### PR DESCRIPTION
And remove old CPP hacks to support older versions.