### PR TITLE
Migrate away from deprecated stack.yaml format.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 resolver: lts-13.1
 packages:
-  - location: '.'
+  - .
 extra-deps:
   - base-orphans-0.8@sha256:4885caa82ab94fa5cb841d6d06a43a97cdc7e835f346be4f11c1cc5707b886db
   - generic-data-0.3.0.0@sha256:86cac53570f45f5b1e5f54d8765d0a05f1674b3703e4dbb48a919f89c57b3cbc


### PR DESCRIPTION
The old format doesn't work with latest release of stack, and
breaks CI.