### PR TITLE
Add Overflow example which fails only with >=4 threads

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -122,6 +122,7 @@ test-suite quickcheck-state-machine-test
                        ErrorEncountered,
                        Hanoi,
                        MemoryReference,
+                       Overflow,
                        ProcessRegistry,
                        ShrinkingProps,
                        TicketDispenser,

--- a/src/Test/StateMachine/DotDrawing.hs
+++ b/src/Test/StateMachine/DotDrawing.hs
@@ -4,6 +4,7 @@
 
 module Test.StateMachine.DotDrawing
   ( GraphOptions (..)
+  , GraphvizOutput (..)
   , Rose (..)
   , printDotGraph
   ) where

--- a/test/Overflow.hs
+++ b/test/Overflow.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE ExplicitNamespaces   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+
+module Overflow
+  ( prop_sequential_overflow
+  , prop_parallel_overflow
+  , prop_nparallel_overflow
+  ) where
+
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.MVar
+import           Control.Monad
+import           Data.Int
+import           GHC.Generics
+                   (Generic, Generic1)
+import           Prelude
+import           System.Random
+                   (randomRIO)
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic (monadicIO)
+import           Test.StateMachine
+import           Test.StateMachine.DotDrawing
+import           Test.StateMachine.Parallel
+import           Test.StateMachine.Types(Reference(..), Symbolic(..))
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+data Command r
+  = Create
+  | Check (Reference (Opaque (MVar Int8)) r)
+  | BackAndForth Int (Reference (Opaque (MVar Int8)) r)
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
+
+deriving instance Show (Command Symbolic)
+deriving instance Read (Command Symbolic)
+deriving instance Show (Command Concrete)
+
+data Response r
+    = Created (Reference (Opaque (MVar Int8)) r)
+    | IsNegative Bool
+    | Unit
+    deriving (Eq, Generic1, Rank2.Foldable)
+
+deriving instance Show (Response Symbolic)
+deriving instance Read (Response Symbolic)
+deriving instance Show (Response Concrete)
+
+newtype Model r = Model [(Reference (Opaque (MVar Int8)) r, Int8)]
+  deriving (Generic, Show)
+
+getVars :: Model r -> [Reference (Opaque (MVar Int8)) r]
+getVars (Model ls) = fst <$> ls
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model []
+
+transition :: Model r -> Command r -> Response r -> Model r
+transition m@(Model model) cmd resp = case (cmd, resp) of
+  (Create, Created var)    -> Model ((var, 0) : model)
+  (Check _, IsNegative _)  -> m
+  (BackAndForth _ _, Unit) -> m
+  _                        -> error "impossible to transition!"
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition m cmd = case cmd of
+  Create             -> Top
+  Check var          -> var `member` getVars m
+  BackAndForth _ var -> var `member` getVars m
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition _ cmd resp = case (cmd, resp) of
+  (Create, Created _)      -> Top
+  (Check _, IsNegative bl) -> bl .== False
+  (BackAndForth _ _, Unit) -> Top
+  _                        -> Bot
+
+semantics :: Command Concrete -> IO (Response Concrete)
+semantics cmd = case cmd of
+  Create        -> Created <$> (reference . Opaque <$> newMVar 0)
+  Check var     -> do
+    val <- readMVar (opaque var)
+    return $ IsNegative $ val < 0
+  BackAndForth n var -> do
+    modifyMVar_ (opaque var) $ \x -> return $ x + fromIntegral n
+    threadDelay =<< randomRIO (0, 5000)
+    modifyMVar_ (opaque var) $ \x -> return $ x - fromIntegral n
+    return Unit
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock _ cmd = case cmd of
+  Create           -> Created <$> genSym
+  Check _var       -> return $ IsNegative False
+  BackAndForth _ _ -> return $ Unit
+
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator (Model []) = Just (return Create)
+generator m            = Just $ frequency
+                [ (1, return Create)
+                , (3, genBackAndForth m)
+                , (3, genCheck m)
+                ]
+
+genCheck :: Model Symbolic -> Gen (Command Symbolic)
+genCheck m = do
+  Check <$> elements (getVars m)
+
+genBackAndForth :: Model Symbolic -> Gen (Command Symbolic)
+genBackAndForth m = do
+  BackAndForth 50 <$> elements (getVars m)
+
+shrinker :: Model Symbolic -> Command Symbolic -> [Command Symbolic]
+shrinker _ (BackAndForth n var) = [ BackAndForth n' var | n' <- shrink n ]
+shrinker _ _             = []
+
+sm :: StateMachine Model Command IO Response
+sm = StateMachine initModel transition precondition postcondition
+           Nothing generator shrinker semantics mock
+
+prop_sequential_overflow :: Property
+prop_sequential_overflow = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
+  (hist, _model, res) <- runCommands sm cmds
+  prettyCommands sm hist (res === Ok)
+
+prop_parallel_overflow :: Property
+prop_parallel_overflow = forAllParallelCommands sm $ \cmds -> monadicIO $ do
+    prettyParallelCommandsWithOpts cmds (Just $ GraphOptions "counter_example.png" Png) =<< runParallelCommands sm cmds
+
+prop_nparallel_overflow :: Int -> Property
+prop_nparallel_overflow np = forAllNParallelCommands sm np $ \cmds -> monadicIO $ do
+    prettyNParallelCommandsWithOpts cmds (Just $ GraphOptions ("counter_example_" ++ show np ++ ".png") Png) =<< runNParallelCommands sm cmds

--- a/test/Overflow.hs
+++ b/test/Overflow.hs
@@ -33,6 +33,10 @@ import           Test.StateMachine.Parallel
 import           Test.StateMachine.Types(Reference(..), Symbolic(..))
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
+-- The Model is a set of references of Int8. Command BackAndForth picks a random reference and adds a
+-- constant number (in an atomic way) and then substract the same number (in an atomic way).
+-- If there are enough threads (4 in this case) the result can overflow.
+
 data Command r
   = Create
   | Check (Reference (Opaque (MVar Int8)) r)
@@ -105,23 +109,27 @@ mock _ cmd = case cmd of
 
 generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
 generator (Model []) = Just (return Create)
-generator m            = Just $ frequency
+generator m          = Just $ frequency
                 [ (1, return Create)
                 , (3, genBackAndForth m)
                 , (3, genCheck m)
                 ]
 
 genCheck :: Model Symbolic -> Gen (Command Symbolic)
-genCheck m = do
+genCheck m =
   Check <$> elements (getVars m)
 
 genBackAndForth :: Model Symbolic -> Gen (Command Symbolic)
 genBackAndForth m = do
-  BackAndForth 50 <$> elements (getVars m)
+  -- The upper limit here must have the property 2 * n < 128 <= 3 * n, so that
+  -- there is a counter example for >= 4 threads.
+  -- The lower limit only affects how fast a counterexample will be found.
+  n <- choose (30,60)
+  BackAndForth n <$> elements (getVars m)
 
 shrinker :: Model Symbolic -> Command Symbolic -> [Command Symbolic]
 shrinker _ (BackAndForth n var) = [ BackAndForth n' var | n' <- shrink n ]
-shrinker _ _             = []
+shrinker _ _                    = []
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transition precondition postcondition
@@ -134,8 +142,10 @@ prop_sequential_overflow = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
 
 prop_parallel_overflow :: Property
 prop_parallel_overflow = forAllParallelCommands sm $ \cmds -> monadicIO $ do
-    prettyParallelCommandsWithOpts cmds (Just $ GraphOptions "counter_example.png" Png) =<< runParallelCommands sm cmds
+    prettyParallelCommandsWithOpts cmds opts =<< runParallelCommands sm cmds
+      where opts = Just $ GraphOptions "overflow.png" Png
 
 prop_nparallel_overflow :: Int -> Property
 prop_nparallel_overflow np = forAllNParallelCommands sm np $ \cmds -> monadicIO $ do
-    prettyNParallelCommandsWithOpts cmds (Just $ GraphOptions ("counter_example_" ++ show np ++ ".png") Png) =<< runNParallelCommands sm cmds
+    prettyNParallelCommandsWithOpts cmds opts =<< runNParallelCommands sm cmds
+      where opts = Just $ GraphOptions ("overflow-" ++ show np ++ ".png") Png

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,6 +26,7 @@ import           Echo
 import           ErrorEncountered
 import           Hanoi
 import           MemoryReference
+import           Overflow
 import           ProcessRegistry
 import qualified ShrinkingProps
 import           Test.StateMachine.Markov
@@ -68,6 +69,11 @@ tests docker0 = testGroup "Tests"
       , testProperty "ShrinkParallelEquivalence" prop_pairs_shrink_parallel_equivalence
       , testProperty "ShrinkAndValidateParallelEquivalence" prop_pairs_shrinkAndValidate_equivalence
       , testProperty "ShrinkPairsEquialence"     prop_pairs_shrink_parallel
+      ]
+  , testGroup "Overflow"
+      [ testProperty "Overflow 2 threads" prop_parallel_overflow
+      , testProperty "Overflow 3 threads" $ prop_nparallel_overflow 3
+      , testProperty "Overflow 4 threads" $ expectFailure $ prop_nparallel_overflow 4
       ]
   , testGroup "ErrorEncountered"
       [ testProperty "Sequential" prop_error_sequential


### PR DESCRIPTION
Signed-off-by: kderme <k.dermenz@gmail.com>

> Can you think of an example bug which only manifests itself when 3 or more threads are used? Would be > nice to have such an example, but doesn't have to be part of this PR.

This is an example which only manifests when there are >= 4 threads.

The Model is a set of references of Int8. Some commands pick a random reference and add a constant number (in an atomic way) and then substract the same number (in an atomic way). If there are many threads the result can overflow.

![counter_example_4](https://user-images.githubusercontent.com/11467473/60371265-6fa15680-9a01-11e9-99fc-3e5d44ad0086.png)

Check also how commands are shrunk to sum to 128 (which is the minimum overflow point)