### PR TITLE
fix generators

### DIFF
--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -309,7 +309,8 @@ postconditions _         _              _              = error "postconditions"
 -- * How to generate and shrink programs.
 
 generator :: Model Symbolic -> Maybe (Gen (Action Symbolic))
-generator (Model m) = Just $ frequency
+generator (Model []) = Just $ PostUser <$> arbitrary
+generator (Model m)  = Just $ frequency
   [ (1, PostUser   <$> arbitrary)
   , (3, GetUser    <$> elements (map fst m))
   , (4, IncAgeUser <$> elements (map fst m))

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -125,6 +125,7 @@ mock (Model m) cmd = case cmd of
       | otherwise -> pure WriteFailed
 
 generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator (Model [])    = Just $ pure Create
 generator (Model model) = Just $ frequency
   [ (1, pure Create)
   , (4, Read  <$> elements (domain model))

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -281,6 +281,8 @@ lockstep model cmd (At resp) = event model cmd $ \resp' ->
 -------------------------------------------------------------------------------}
 
 generator :: Model Symbolic -> Maybe (Gen (Cmd :@ Symbolic))
+generator (Model _ [] cid)        = Just $
+      At . CreateRef cid Nothing <$> small
 generator (Model _ knownRefs cid) = Just $ oneof [
       At . CreateRef cid Nothing <$> small
     , small >>= \n -> At . Incr cid Nothing <$> replicateM n pickRef
@@ -290,8 +292,8 @@ generator (Model _ knownRefs cid) = Just $ oneof [
     pickRef :: Gen (Reference IOVar Symbolic)
     pickRef = elements (map fst knownRefs)
 
-    small :: Gen Int
-    small = choose (0,30)
+small :: Gen Int
+small = choose (0,30)
 
 -- | Shrinker
 --


### PR DESCRIPTION
Signed-off-by: kderme <k.dermenz@gmail.com>
Related issue https://github.com/advancedtelematic/quickcheck-state-machine/issues/327

Note how this exception, which appears very often is most of the times hidden because of laziness:
```
> undefined `Prelude.elem` []
False
```

So the generation creates the exception many times, but the precondition hides it, since it never evaluates the undefined thunk.