### PR TITLE
Show which exception was thrown

### DIFF
--- a/src/Test/StateMachine/Sequential.hs
+++ b/src/Test/StateMachine/Sequential.hs
@@ -377,7 +377,7 @@ executeCommands StateMachine {..} hchan pid check =
           case ecresp of
             Left err    -> do
               atomically (writeTChan hchan (pid, Exception err))
-              return ExceptionThrown
+              return $ ExceptionThrown err
             Right cresp -> do
               let cvars = getUsedConcrete cresp
               if length vars /= length cvars

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -98,7 +98,7 @@ data Reason
   | PreconditionFailed String
   | PostconditionFailed String
   | InvariantBroken String
-  | ExceptionThrown
+  | ExceptionThrown String
   | MockSemanticsMismatch
   deriving (Eq, Show)
 


### PR DESCRIPTION
Signed-off-by: kderme <k.dermenz@gmail.com>
Related issue: https://github.com/advancedtelematic/quickcheck-state-machine/issues/340
I have found this quite useful while debugging. It prints exactly which exception was thrown while running the semantics:
`ExceptionThrown "\"user error (failed)\"" /= Ok`
instead of
`ExceptionThrown /= Ok `
