### PR TITLE
Bump maxSuccess from 6000 to 10000 for CrashAndLogicBugParallel.

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -56,7 +56,7 @@ tests docker0 = testGroup "Tests"
       , testProperty "RaceBugParallel"   (expectFailure (prop_parallel   Race))
       , testProperty "CrashBugParallel"                 (prop_parallel'  Crash)
       , testProperty "CrashAndLogicBugParallel"
-          (expectFailure (withMaxSuccess 6000 (prop_parallel' CrashAndLogic)))
+          (expectFailure (withMaxSuccess 10000 (prop_parallel' CrashAndLogic)))
       , testProperty "PreconditionFailed" prop_precondition
       , testProperty "ExistsCommands"     prop_existsCommands
       , testProperty "NoBug 1 thread"            (prop_nparallel None 1)


### PR DESCRIPTION
As we are still seeing this fail sometimes on CI:

  https://travis-ci.org/advancedtelematic/quickcheck-state-machine/jobs/563426231#L1015