### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.hi
 *.o
 dist-newstyle/
+dist/
 .ghc.environment.*
+stack.yaml.lock
 *~
 *.swp
+
+cleanup-test-folder/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ stack.yaml.lock
 *~
 *.swp
 
-cleanup-test-folder/
+cleanup-test-folder*

--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -118,6 +118,7 @@ test-suite quickcheck-state-machine-test
 
   other-modules:       Bookstore,
                        CircularBuffer,
+                       Cleanup,
                        CrudWebserverDb,
                        DieHard,
                        Echo,

--- a/src/Test/StateMachine.hs
+++ b/src/Test/StateMachine.hs
@@ -29,6 +29,7 @@ module Test.StateMachine
   , runSavedCommands
   , showLabelledExamples
   , showLabelledExamples'
+  , noCleanup
 
   -- * Parallel property combinators
   , forAllParallelCommands
@@ -42,6 +43,8 @@ module Test.StateMachine
   , runNParallelCommandsNTimes
   , prettyNParallelCommands
   , prettyParallelCommands
+  , prettyParallelCommandsWithOpts
+  , prettyNParallelCommandsWithOpts
   , checkCommandNamesParallel
   , coverCommandNamesParallel
   , commandNamesParallel

--- a/src/Test/StateMachine/Types.hs
+++ b/src/Test/StateMachine/Types.hs
@@ -36,6 +36,7 @@ module Test.StateMachine.Types
   , toPairUnsafe'
   , Reason(..)
   , isOK
+  , noCleanup
   , module Test.StateMachine.Types.Environment
   , module Test.StateMachine.Types.GenSym
   , module Test.StateMachine.Types.History
@@ -68,7 +69,11 @@ data StateMachine model cmd m resp = StateMachine
   , shrinker       :: model Symbolic -> cmd Symbolic -> [cmd Symbolic]
   , semantics      :: cmd Concrete -> m (resp Concrete)
   , mock           :: model Symbolic -> cmd Symbolic -> GenSym (resp Symbolic)
+  , cleanup        :: model Concrete -> m ()
   }
+
+noCleanup :: Monad m => model Concrete -> m ()
+noCleanup _ = return ()
 
 -- | Previously symbolically executed command
 --

--- a/src/Test/StateMachine/Types/History.hs
+++ b/src/Test/StateMachine/Types/History.hs
@@ -24,6 +24,7 @@ module Test.StateMachine.Types.History
   , Operation(..)
   , makeOperations
   , interleavings
+  , operationsPath
   , completeHistory
   )
   where
@@ -119,6 +120,13 @@ interleavings es =
     filter1 _ []                   = []
     filter1 p (x : xs) | p x       = x : filter1 p xs
                        | otherwise = xs
+
+operationsPath :: Forest (Operation cmd resp) -> [Operation cmd resp]
+operationsPath = go []
+    where
+      go :: [a] -> Forest a -> [a]
+      go acc [] = reverse acc
+      go acc (Node a f : _) = go (a:acc) f
 
 ------------------------------------------------------------------------
 

--- a/test/Bookstore.hs
+++ b/test/Bookstore.hs
@@ -402,7 +402,7 @@ mock (Model m) cmd = return $ case cmd of
 
 sm :: Bug -> StateMachine Model Command (ReaderT ConnectInfo IO) Response
 sm bug = StateMachine initModel transitions preconditions postconditions
-  Nothing generator shrinker (semantics bug) mock
+  Nothing generator shrinker (semantics bug) mock noCleanup
 
 runner :: IO String -> ReaderT ConnectInfo IO Property -> IO Property
 runner io p = do

--- a/test/CircularBuffer.hs
+++ b/test/CircularBuffer.hs
@@ -281,7 +281,7 @@ mock (Model m) (Len buffer) = case lookup buffer m of
 sm :: Version -> Bugs -> StateMachine Model Action IO Response
 sm version bugs = StateMachine
   initModel transition (precondition bugs) postcondition
-  Nothing (generator version) shrinker (semantics bugs) mock
+  Nothing (generator version) shrinker (semantics bugs) mock noCleanup
 
 -- | Property parameterized by spec version and bugs.
 prepropcircularBuffer :: Version -> Bugs -> Property

--- a/test/Cleanup.hs
+++ b/test/Cleanup.hs
@@ -244,7 +244,7 @@ prop_parallel_clean testing bug dc = forAllParallelCommands smUnused $ \cmds -> 
     c <- liftIO $ newMVar 0
     ref <- liftIO $ newMVar 0
     let sm' = sm c ref testDir bug dc
-    ret <- runParallelCommands sm' cmds
+    ret <- runParallelCommandsNTimes 2 sm' cmds
     ls <- liftIO $ listDirectory testDir
     liftIO $ removePathForcibly testDir
     case testing of
@@ -267,7 +267,7 @@ prop_nparallel_clean np testing bug dc = forAllNParallelCommands smUnused np $ \
     c <- liftIO $ newMVar 0
     ref <- liftIO $ newMVar 0
     let sm' = sm c ref testDir bug dc
-    ret <- runNParallelCommands sm' cmds
+    ret <- runNParallelCommandsNTimes 2 sm' cmds
     ls <- liftIO $ listDirectory testDir
     liftIO $ removePathForcibly testDir
     case testing of

--- a/test/Cleanup.hs
+++ b/test/Cleanup.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE ExplicitNamespaces   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cleanup (
+    Bug (..)
+  , DoubleCleanup (..)
+  , FinalTest (..)
+  , prop_sequential_clean
+  , prop_parallel_clean
+  , prop_nparallel_clean
+  ) where
+
+import           Control.Concurrent.MVar
+import           Control.Exception
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.Functor.Classes
+                   (Ord1)
+import           Data.List ((\\))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Prelude
+import           System.Directory
+import           System.IO
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic (monadicIO)
+import           GHC.Generics
+                   (Generic, Generic1)
+import           Test.StateMachine
+import           Test.StateMachine.Types(Reference(..), Symbolic(..))
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.StateMachine.Utils (whenFailM)
+
+{-----------------------------------------------------------------------------------
+  This example in mainly used to check how well cleanup of recourses works. In our
+  case recourses are files created on the @testDirectory@ (not open handles, just
+  files). So it is easy, by the end of the tests to test if there any any recourses
+  which are not cleaned up, by the end of the tests.
+
+  We also test different scenarios, like injected exceptions in semantics
+  (before and after the recourse is created). Tests also reveal what happens when
+  cleaning up a recourse for the second time is not a no-op.
+
+-----------------------------------------------------------------------------------}
+data Command r
+  = Create String
+  | Delete (Reference (Opaque FileRef) r)
+  | Ls
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
+
+deriving instance Show (Command Symbolic)
+deriving instance Read (Command Symbolic)
+deriving instance Show (Command Concrete)
+
+data Response r
+  = Created (Reference (Opaque FileRef) r)
+  | Deleted
+  | Contents [String]
+  deriving (Eq, Generic1, Rank2.Foldable)
+
+deriving instance Show (Response Symbolic)
+deriving instance Read (Response Symbolic)
+deriving instance Show (Response Concrete)
+
+data Model r = Model {
+      files   :: Map (Reference (Opaque FileRef) r) String
+    , counter :: Int
+    , semanticsCounter :: Opaque (MVar Int)
+  }
+  deriving (Generic, Show)
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: MVar Int -> Model r
+initModel sc= Model Map.empty 0 (Opaque sc)
+
+transition :: Ord1 r => Model r -> Command r -> Response r -> Model r
+transition m@Model {..} cmd resp = case (cmd, resp) of
+    (Create p, Created ref) -> m {files = Map.insert ref p files, counter = counter + 1}
+    (Delete ref, Deleted)   -> m {files = Map.delete ref files}
+    (Ls, Contents _)        -> m
+    _ -> error "transition impossible"
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition Model {..} cmd = case cmd of
+    Create p   -> Boolean $ notElem p (Map.elems files)
+  --                       && (counter < 7)
+    Delete ref -> Boolean $ Map.member ref files
+    Ls         -> Top
+
+sameElements :: Eq a => [a] -> [a] -> Bool
+sameElements x y = null (x \\ y) && null (y \\ x)
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition  Model{..} cmd resp = case (cmd, resp) of
+  (Create _,      Created _) -> Top
+  (Delete _, Deleted)        -> Top
+  (Ls, Contents ls)          -> if sameElements ls (Map.elems files) then Top
+        else Annotate ("Not same elements between " ++ show ls ++ "and " ++ show (Map.elems files)) Bot
+  _ -> Bot
+
+data MVarC a = MVarC (MVar a) Int
+type FileRef = MVarC (String, Bool)
+
+removeFileRef :: DoubleCleanup -> FileRef -> IO ()
+removeFileRef dc (MVarC r _) = modifyMVar_ r $ \(file, isHere) -> do
+      case (isHere, dc) of
+        (_, ReDo) -> removeFile file
+        (True, _) -> removeFile file
+        (False, NoOp) -> return ()
+      return (file, False)
+
+instance Eq (MVarC a) where
+    MVarC _ a == MVarC _ b = a == b
+
+instance Ord (MVarC a) where
+    compare (MVarC _ a) (MVarC _ b) = compare a b
+
+semantics :: MVar Int ->  Bug -> Command Concrete -> IO (Response Concrete)
+semantics counter bug cmd = case cmd of
+    Create f -> createFile f
+            `onException` removePathForcibly (makePath f)
+    Delete ref -> do
+        let MVarC lockedFile _ = unOpaque $ concrete ref
+        modifyMVar_ lockedFile $ \(file, _) -> do
+            removeFile file
+            return (file, False)
+        return Deleted
+    Ls -> do
+        ls <- listDirectory testDirectory
+        return $ Contents ls
+    where
+        createFile :: String -> IO (Response Concrete)
+        createFile f = do
+            let path = makePath f
+            c <- modifyMVar counter $ \n -> return (n + 1, n)
+            when (c > 3 && bug == Exception) $
+                throwIO $ userError "semantics injected bug"
+            withFile path WriteMode (\_ -> return ())
+            when (c > 3 && bug == ExceptionAfter) $
+                throwIO $ userError "semantics injected bug"
+            ref <- newMVar (path, True)
+            return $ Created $ reference $ Opaque $ MVarC ref c
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock Model{..} cmd = case cmd of
+    Create _ -> Created <$> genSym
+    Delete _ -> return Deleted
+    Ls       -> return $ Contents $ Map.elems files
+
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator Model{..} = Just $ frequency
+    [ (7, return $ Create $ mkFileName counter)
+    , (if Map.null files then 0 else 3, Delete . fst <$> elements (Map.toList files))
+    , (1, return Ls)
+    ]
+
+shrinker :: Model Symbolic -> Command Symbolic -> [Command Symbolic]
+shrinker _ _             = []
+
+cleanup :: DoubleCleanup -> Model Concrete -> IO ()
+cleanup dc Model{..} = do
+    forM_ (Map.keys files) $ \ref ->
+        removeFileRef dc $ unOpaque $ concrete ref
+    modifyMVar_ (unOpaque semanticsCounter) (\_ -> return 0)
+
+sm :: MVar Int -> Bug -> DoubleCleanup -> StateMachine Model Command IO Response
+sm counter bug dc = StateMachine (initModel counter) transition precondition postcondition
+           Nothing generator shrinker (semantics counter bug) mock (cleanup dc)
+
+smUnused :: StateMachine Model Command IO Response
+smUnused = sm undefined undefined undefined
+
+prop_sequential_clean :: FinalTest -> Bug -> DoubleCleanup -> Property
+prop_sequential_clean testing bug dc = forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
+    liftIO $ do
+        removePathForcibly testDirectory
+        createDirectory testDirectory
+    c <- liftIO $ newMVar 0
+    let sm' = sm c bug dc
+    (hist, _model, res) <- runCommands sm' cmds
+    ls <- liftIO $ listDirectory testDirectory
+    case testing of
+        Regular -> prettyCommands sm' hist $ checkCommandNames cmds (res === Ok)
+        Files   -> printFiles ls `whenFailM` (ls === [])
+
+prop_parallel_clean :: FinalTest -> Bug -> DoubleCleanup -> Property
+prop_parallel_clean testing bug dc = forAllParallelCommands smUnused $ \cmds -> monadicIO $ do
+    liftIO $ do
+        removePathForcibly testDirectory
+        createDirectory testDirectory
+    c <- liftIO $ newMVar 0
+    let sm' = sm c bug dc
+    ret <- runParallelCommands sm' cmds
+    ls <- liftIO $ listDirectory testDirectory
+    case testing of
+        Regular -> prettyParallelCommands cmds ret
+        Files   -> printFiles ls `whenFailM` (ls === [])
+
+prop_nparallel_clean :: Int -> FinalTest -> Bug -> DoubleCleanup -> Property
+prop_nparallel_clean np testing bug dc = forAllNParallelCommands smUnused np $ \cmds -> monadicIO $ do
+    liftIO $ do
+        removePathForcibly testDirectory
+        createDirectory testDirectory
+    c <- liftIO $ newMVar 0
+    let sm' = sm c bug dc
+    ret <- runNParallelCommands sm' cmds
+    ls <- liftIO $ listDirectory testDirectory
+    case testing of
+        Regular -> prettyNParallelCommands cmds ret
+        Files   -> printFiles ls `whenFailM` (ls === [])
+
+printFiles :: [String] -> IO ()
+printFiles ls' =
+    putStrLn $ "Cleanup was not complete. Found files " ++ show ls'
+
+data Bug = NoBug
+         | Exception
+         | ExceptionAfter
+         deriving (Eq, Show)
+
+data DoubleCleanup = NoOp
+                   | ReDo
+
+data FinalTest = Regular
+               | Files
+                 deriving (Eq, Show)
+
+makePath :: String -> String
+makePath file = testDirectory ++ "/" ++ file
+
+mkFileName :: Int -> String
+mkFileName n = "file" ++ show n
+
+testDirectory :: String
+testDirectory = "cleanup-test-folder"

--- a/test/CrudWebserverDb.hs
+++ b/test/CrudWebserverDb.hs
@@ -349,7 +349,7 @@ mock (Model m) act = case act of
 
 sm :: StateMachine Model Action (ReaderT ClientEnv IO) Response
 sm = StateMachine initModel transitions preconditions postconditions
-       Nothing generator shrinker semantics mock
+       Nothing generator shrinker semantics mock noCleanup
 
 ------------------------------------------------------------------------
 -- * Sequential property

--- a/test/DieHard.hs
+++ b/test/DieHard.hs
@@ -155,7 +155,7 @@ mock _ _ = return Done
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transitions preconditions postconditions
-       Nothing generator shrinker semantics mock
+       Nothing generator shrinker semantics mock noCleanup
 
 prop_dieHard :: Property
 prop_dieHard = forAllCommands sm Nothing $ \cmds -> monadicIO $ do

--- a/test/Echo.hs
+++ b/test/Echo.hs
@@ -112,6 +112,7 @@ echoSM env = StateMachine
     , shrinker = mShrinker
     , semantics = mSemantics
     , mock = mMock
+    , cleanup = noCleanup
     }
     where
       mTransitions :: Model r -> Action r -> Response r -> Model r

--- a/test/ErrorEncountered.hs
+++ b/test/ErrorEncountered.hs
@@ -139,7 +139,7 @@ shrinker _ _             = []
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transition precondition postcondition
-         Nothing generator shrinker semantics mock
+         Nothing generator shrinker semantics mock noCleanup
 
 prop_error_sequential :: Property
 prop_error_sequential = forAllCommands sm Nothing $ \cmds -> monadicIO $ do

--- a/test/Hanoi.hs
+++ b/test/Hanoi.hs
@@ -123,7 +123,7 @@ mock _ _ = return Done
 
 sm :: Int -> StateMachine Model Command IO Response
 sm discs = StateMachine (initModel discs) transitions preconditions postconditions
-       Nothing generator shrinker semantics mock
+       Nothing generator shrinker semantics mock noCleanup
 
 -- A sequential property for Tower of Hanoi with n discs.
 

--- a/test/MemoryReference.hs
+++ b/test/MemoryReference.hs
@@ -194,7 +194,7 @@ shrinker _ _             = []
 
 sm :: Bug -> StateMachine Model Command IO Response
 sm bug = StateMachine initModel transition precondition postcondition
-           Nothing generator shrinker (semantics bug) mock
+           Nothing generator shrinker (semantics bug) mock noCleanup
 
 prop_sequential :: Bug -> Property
 prop_sequential bug = forAllCommands sm' Nothing $ \cmds -> monadicIO $ do

--- a/test/Overflow.hs
+++ b/test/Overflow.hs
@@ -29,7 +29,6 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic (monadicIO)
 import           Test.StateMachine
 import           Test.StateMachine.DotDrawing
-import           Test.StateMachine.Parallel
 import           Test.StateMachine.Types(Reference(..), Symbolic(..))
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
@@ -133,7 +132,7 @@ shrinker _ _                    = []
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transition precondition postcondition
-           Nothing generator shrinker semantics mock
+           Nothing generator shrinker semantics mock noCleanup
 
 prop_sequential_overflow :: Property
 prop_sequential_overflow = forAllCommands sm Nothing $ \cmds -> monadicIO $ do

--- a/test/ProcessRegistry.hs
+++ b/test/ProcessRegistry.hs
@@ -425,7 +425,7 @@ mock m act = case act of
 
 sm :: StateMachine Model Action IO Response
 sm = StateMachine initModel transition precondition postcondition
-       Nothing generator shrinker semantics mock
+       Nothing generator shrinker semantics mock noCleanup
 
 markov :: Markov State Action_ Double
 markov = makeMarkov

--- a/test/ShrinkingProps.hs
+++ b/test/ShrinkingProps.hs
@@ -343,6 +343,7 @@ sm = QSM.StateMachine {
        , semantics     = semantics
        , mock          = mock
        , invariant     = Nothing
+       , cleanup       = noCleanup
        }
 
 {-------------------------------------------------------------------------------
@@ -701,7 +702,7 @@ prop_one_thread n = forAllCommands sm Nothing $ \cmds -> monadicIO $ do
           cmdsChucks = chunksOf n' sx
           sfxs = (\c -> [c]) . QSM.Commands <$> cmdsChucks
           nParallelCmd = QSM.ParallelCommands {prefix = QSM.Commands px, suffixes = sfxs}
-      res <- runNParallelCommandsNTimes 1 sm $ nParallelCmd
+      res <- runNParallelCommandsNTimes 1 sm nParallelCmd
       let (hist', _ret) = unzip res
       let events = snd <$> (QSM.unHistory hist)
           events' = snd <$> (concat (QSM.unHistory <$> hist'))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -80,60 +80,51 @@ tests docker0 = testGroup "Tests"
                                  $ prop_nparallel_overflow 4
       ]
   , testGroup "Cleanup"
-      [ testProperty "sequentialRegularNoOp" $ prop_sequential_clean   Regular Cleanup.NoBug           NoOp
-      , testProperty "sequentialRegular"     $ prop_sequential_clean   Regular Cleanup.NoBug           ReDo
-      , testProperty "sequentialRegularExceptionNoOp" $ expectFailure
-                                             $ prop_sequential_clean   Regular Cleanup.Exception       NoOp
-      , testProperty "sequentialRegularException" $ expectFailure
-                                             $ prop_sequential_clean   Regular Cleanup.Exception       ReDo
-      , testProperty "sequentialFilesNoOp"   $ prop_sequential_clean   Files   Cleanup.NoBug           NoOp
-      , testProperty "sequentialFiles"       $ prop_sequential_clean   Files   Cleanup.NoBug           ReDo
-      , testProperty "sequentialFilesExceptionNoOp"
-                                             $ prop_sequential_clean   Files   Cleanup.Exception       NoOp
-      , testProperty "sequentialFilesException"
-                                             $ prop_sequential_clean   Files   Cleanup.Exception       ReDo
-      , testProperty "sequentialFilesExceptionAfterNoOp"
-                                             $ prop_sequential_clean   Files   Cleanup.ExceptionAfter  NoOp
-      , testProperty "sequentialFilesExceptionAfterReDo"
-                                             $ prop_sequential_clean  Files   Cleanup.ExceptionAfter  ReDo
-      , testProperty "sequentialEquivalenceNoOp"
-                                             $ prop_sequential_clean  Equiv   Cleanup.NoBug           NoOp
+      [ testProperty "seqRegularNoOp"         $ prop_sequential_clean   Regular    Cleanup.NoBug     NoOp
+      , testProperty "seqRegular"             $ prop_sequential_clean   Regular    Cleanup.NoBug     ReDo
+      , testProperty "seqRegularExcNoOp"
+        $ expectFailure                       $ prop_sequential_clean   Regular    Cleanup.Exception NoOp
+      , testProperty "seqRegularExc"
+        $ expectFailure                       $ prop_sequential_clean   Regular    Cleanup.Exception ReDo
+      , testProperty "seqFilesNoOp"           $ prop_sequential_clean   Files      Cleanup.NoBug     NoOp
+      , testProperty "seqFiles"               $ prop_sequential_clean   Files      Cleanup.NoBug     ReDo
+      , testProperty "seqFilesExcNoOp"        $ prop_sequential_clean   Files      Cleanup.Exception NoOp
+      , testProperty "seqFilesExc"            $ prop_sequential_clean   Files      Cleanup.Exception ReDo
+      , testProperty "seqFilesExcAfterNoOp"   $ prop_sequential_clean   Files      Cleanup.ExcAfter  NoOp
+      , testProperty "seqFilesExcAfterReDo"   $ prop_sequential_clean   Files      Cleanup.ExcAfter  ReDo
+      , testProperty "seqEquivNoOp"           $ prop_sequential_clean  (Eq False)  Cleanup.NoBug     NoOp
 
+      , testProperty "2-threadsRegularNoOp"   $ prop_parallel_clean     Regular    Cleanup.NoBug     NoOp
+      , testProperty "2-threadsRegular"       $ prop_parallel_clean     Regular    Cleanup.NoBug     ReDo
+      , testProperty "2-threadsRegularExc"
+        $ expectFailure                       $ prop_parallel_clean     Regular    Cleanup.Exception NoOp
+      , testProperty "2-threadsRegularExc"
+        $ expectFailure                       $ prop_parallel_clean     Regular    Cleanup.Exception ReDo
+      , testProperty "2-threadsFilesNoOp"     $ prop_parallel_clean     Files      Cleanup.NoBug     NoOp
+      , testProperty "2-threadsFiles"         $ prop_parallel_clean     Files      Cleanup.NoBug     ReDo
+      , testProperty "2-threadsFilesExcNoOp"  $ prop_parallel_clean     Files      Cleanup.Exception NoOp
+      , testProperty "2-threadsFilesExc"
+        $ expectFailure $ withMaxSuccess 1000 $ prop_parallel_clean     Files      Cleanup.Exception ReDo
+      , testProperty "2-threadsFilesExcAfter" $ prop_parallel_clean     Files      Cleanup.ExcAfter  NoOp
+      , testProperty "2-threadsEquivNoOp"     $ prop_parallel_clean     (Eq False) Cleanup.NoBug     NoOp
+      , testProperty "2-threadsEquivFailingNoOp"
+        $ expectFailure $ withMaxSuccess 1000 $ prop_parallel_clean     (Eq True)  Cleanup.NoBug     NoOp
 
-      , testProperty "2-threadsRegularNoOp"  $ prop_parallel_clean     Regular Cleanup.NoBug           NoOp
-      , testProperty "2-threadsRegular"      $ prop_parallel_clean     Regular Cleanup.NoBug           ReDo
-      , testProperty "2-threadsRegularException"  $ expectFailure
-                                             $ prop_parallel_clean     Regular Cleanup.Exception       NoOp
-      , testProperty "2-threadsRegularException" $ expectFailure
-                                             $ prop_parallel_clean     Regular Cleanup.Exception       ReDo
-      , testProperty "2-threadsFilesNoOp"    $ prop_parallel_clean     Files   Cleanup.NoBug           NoOp
-      , testProperty "2-threadsFiles"        $ prop_parallel_clean     Files   Cleanup.NoBug           ReDo
-      , testProperty "2-threadsFilesExceptionNoOp"
-                                             $ prop_parallel_clean     Files   Cleanup.Exception       NoOp
-      , testProperty "2-threadsFilesException" $ expectFailure $ withMaxSuccess 1000
-                                             $ prop_parallel_clean     Files   Cleanup.Exception       ReDo
-      , testProperty "2-threadsFilesExceptionAfter"
-                                             $ prop_parallel_clean     Files   Cleanup.ExceptionAfter  NoOp
-      , testProperty "2-threadsEquivalenceNoOp"
-                                             $ prop_parallel_clean     Equiv   Cleanup.NoBug           NoOp
-
-
-      , testProperty "3-threadsRegularNoOp"  $ prop_nparallel_clean  3 Regular Cleanup.NoBug           NoOp
-      , testProperty "3-threadsRegular"      $ prop_nparallel_clean  3 Regular Cleanup.NoBug           ReDo
-      , testProperty "3-threadsRegularException"  $ expectFailure
-                                             $ prop_nparallel_clean  3 Regular Cleanup.Exception       NoOp
-      , testProperty "3-threadsRegularException"  $ expectFailure
-                                             $ prop_nparallel_clean  3 Regular Cleanup.Exception       ReDo
-      , testProperty "3-threadsFiles"        $ prop_nparallel_clean  3 Files   Cleanup.NoBug           NoOp
-      , testProperty "3-threadsFiles"        $ prop_nparallel_clean  3 Files   Cleanup.NoBug           ReDo
-      , testProperty "3-threadsFilesExceptionNoOp"
-                                             $ prop_nparallel_clean  3 Files   Cleanup.Exception       NoOp
-      , testProperty "3-threadsFilesException" $ expectFailure $ withMaxSuccess 1000
-                                             $ prop_nparallel_clean  3 Files   Cleanup.Exception       ReDo
-      , testProperty "3-threadsFilesExceptionAfter"
-                                             $ prop_nparallel_clean  3 Files   Cleanup.ExceptionAfter  NoOp
-      , testProperty "3-threadsEquivalenceNoOp"
-                                             $ prop_nparallel_clean  3 Equiv   Cleanup.NoBug           NoOp
+      , testProperty "3-threadsRegularNoOp"   $ prop_nparallel_clean  3 Regular    Cleanup.NoBug     NoOp
+      , testProperty "3-threadsRegular"       $ prop_nparallel_clean  3 Regular    Cleanup.NoBug     ReDo
+      , testProperty "3-threadsRegularExc"    $ expectFailure
+                                              $ prop_nparallel_clean  3 Regular    Cleanup.Exception NoOp
+      , testProperty "3-threadsRegularExc"
+        $ expectFailure                       $ prop_nparallel_clean  3 Regular    Cleanup.Exception ReDo
+      , testProperty "3-threadsFilesNoOp"     $ prop_nparallel_clean  3 Files      Cleanup.NoBug     NoOp
+      , testProperty "3-threadsFiles"         $ prop_nparallel_clean  3 Files      Cleanup.NoBug     ReDo
+      , testProperty "3-threadsFilesExcNoOp"  $ prop_nparallel_clean  3 Files      Cleanup.Exception NoOp
+      , testProperty "3-threadsFilesExc"
+        $ expectFailure $ withMaxSuccess 1000 $ prop_nparallel_clean  3 Files      Cleanup.Exception ReDo
+      , testProperty "3-threadsFilesExcAfter" $ prop_nparallel_clean  3 Files      Cleanup.ExcAfter  NoOp
+      , testProperty "3-threadsEquivNoOp"     $ prop_nparallel_clean  3 (Eq False) Cleanup.NoBug     NoOp
+      , testProperty "3-threadsEquivFailingNoOp"
+        $ expectFailure $ withMaxSuccess 1000 $ prop_nparallel_clean  3 (Eq True)  Cleanup.NoBug     NoOp
       ]
   , testGroup "ErrorEncountered"
       [ testProperty "Sequential" prop_error_sequential

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -95,7 +95,9 @@ tests docker0 = testGroup "Tests"
       , testProperty "sequentialFilesExceptionAfterNoOp"
                                              $ prop_sequential_clean   Files   Cleanup.ExceptionAfter  NoOp
       , testProperty "sequentialFilesExceptionAfterReDo"
-                                              $ prop_sequential_clean   Files   Cleanup.ExceptionAfter ReDo
+                                             $ prop_sequential_clean  Files   Cleanup.ExceptionAfter  ReDo
+      , testProperty "sequentialEquivalenceNoOp"
+                                             $ prop_sequential_clean  Equiv   Cleanup.NoBug           NoOp
 
 
       , testProperty "2-threadsRegularNoOp"  $ prop_parallel_clean     Regular Cleanup.NoBug           NoOp
@@ -111,10 +113,12 @@ tests docker0 = testGroup "Tests"
       , testProperty "2-threadsFilesException" $ expectFailure $ withMaxSuccess 1000
                                              $ prop_parallel_clean     Files   Cleanup.Exception       ReDo
       , testProperty "2-threadsFilesExceptionAfter"
-                                              $ prop_parallel_clean     Files   Cleanup.ExceptionAfter NoOp
+                                             $ prop_parallel_clean     Files   Cleanup.ExceptionAfter  NoOp
+      , testProperty "2-threadsEquivalenceNoOp"
+                                             $ prop_parallel_clean     Equiv   Cleanup.NoBug           NoOp
 
 
-      , testProperty "3-threadsRegular"      $ prop_nparallel_clean  3 Regular Cleanup.NoBug           NoOp
+      , testProperty "3-threadsRegularNoOp"  $ prop_nparallel_clean  3 Regular Cleanup.NoBug           NoOp
       , testProperty "3-threadsRegular"      $ prop_nparallel_clean  3 Regular Cleanup.NoBug           ReDo
       , testProperty "3-threadsRegularException"  $ expectFailure
                                              $ prop_nparallel_clean  3 Regular Cleanup.Exception       NoOp
@@ -127,7 +131,9 @@ tests docker0 = testGroup "Tests"
       , testProperty "3-threadsFilesException" $ expectFailure $ withMaxSuccess 1000
                                              $ prop_nparallel_clean  3 Files   Cleanup.Exception       ReDo
       , testProperty "3-threadsFilesExceptionAfter"
-                                              $ prop_nparallel_clean  3 Files   Cleanup.ExceptionAfter NoOp
+                                             $ prop_nparallel_clean  3 Files   Cleanup.ExceptionAfter  NoOp
+      , testProperty "3-threadsEquivalenceNoOp"
+                                             $ prop_nparallel_clean  3 Equiv   Cleanup.NoBug           NoOp
       ]
   , testGroup "ErrorEncountered"
       [ testProperty "Sequential" prop_error_sequential

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -94,19 +94,12 @@ tests docker0 = testGroup "Tests"
       , testProperty "seqFilesExcAfterReDo"   $ prop_sequential_clean   Files      Cleanup.ExcAfter  ReDo
       , testProperty "seqEquivNoOp"           $ prop_sequential_clean  (Eq False)  Cleanup.NoBug     NoOp
 
-      , testProperty "2-threadsRegularNoOp"   $ prop_parallel_clean     Regular    Cleanup.NoBug     NoOp
-      , testProperty "2-threadsRegular"       $ prop_parallel_clean     Regular    Cleanup.NoBug     ReDo
       , testProperty "2-threadsRegularExc"
         $ expectFailure                       $ prop_parallel_clean     Regular    Cleanup.Exception NoOp
       , testProperty "2-threadsRegularExc"
         $ expectFailure                       $ prop_parallel_clean     Regular    Cleanup.Exception ReDo
-      , testProperty "2-threadsFilesNoOp"     $ prop_parallel_clean     Files      Cleanup.NoBug     NoOp
-      , testProperty "2-threadsFiles"         $ prop_parallel_clean     Files      Cleanup.NoBug     ReDo
-      , testProperty "2-threadsFilesExcNoOp"  $ prop_parallel_clean     Files      Cleanup.Exception NoOp
       , testProperty "2-threadsFilesExc"
         $ expectFailure $ withMaxSuccess 1000 $ prop_parallel_clean     Files      Cleanup.Exception ReDo
-      , testProperty "2-threadsFilesExcAfter" $ prop_parallel_clean     Files      Cleanup.ExcAfter  NoOp
-      , testProperty "2-threadsEquivNoOp"     $ prop_parallel_clean     (Eq False) Cleanup.NoBug     NoOp
       , testProperty "2-threadsEquivFailingNoOp"
         $ expectFailure $ withMaxSuccess 1000 $ prop_parallel_clean     (Eq True)  Cleanup.NoBug     NoOp
 

--- a/test/TicketDispenser.hs
+++ b/test/TicketDispenser.hs
@@ -197,7 +197,7 @@ withDbLock run = do
 sm :: SharedExclusive -> DbLock -> StateMachine Model Action IO Response
 sm se files = StateMachine
   initModel transitions preconditions postconditions
-  Nothing generator shrinker (semantics se files) mock
+  Nothing generator shrinker (semantics se files) mock noCleanup
 
 smUnused :: SharedExclusive -> StateMachine Model Action IO Response
 smUnused se = sm se (error "dblock used during command creation")

--- a/test/UnionFind.hs
+++ b/test/UnionFind.hs
@@ -219,7 +219,7 @@ shrinker _ _       = []
 
 sm :: StateMachine Model Command IO Response
 sm = StateMachine initModel transition precondition postcondition
-         Nothing generator shrinker semantics mock
+         Nothing generator shrinker semantics mock noCleanup
 
 prop_unionFindSequential :: Property
 prop_unionFindSequential =


### PR DESCRIPTION
This pr adds a new cleanup function field in `StateMachine`. In the sequential case the cleanup is applied to the final model. In the parallel case, a possible model is created from the existing history. So, even if there is some error or an async exception, or we run each program many times using runParallelCommandsNTimes, the cleanup will be made after each execution. For this reason we have replaced `MonadThrow` constraints with `MonadMask`.

This pr adds also a new example test, called `Cleanup`, with many new properties and metaproperties. The test itself is pretty simple. The recourses are files (not open file handles), created and the cleanup tries to delete all files, by looking the References in the final Model. By the end of execution we test if the test folder is indeed empty an this is our property. We test different scenarios like
- Inject exceptions in semantics, to see if cleanup happens succesfully
- We inject error in semantics, in a command which creates a recourse and after it has been created. In this case it is the user's responsibility to do the cleaup of the Command.
- Test in which cases the cleanup has to be a no-op. In our tests it seems that for the parallel case it is possible that cleanup is called more than once for some recourse, so it has to be a no-op.
- We have metaproperties which test the function which creates the Model from the History. In the sequential case, this is deterministic, but in the Parallel case it is not. We compare the Model created by two different executions and we see that they are not strictly equal.

This pr introduces a breaking api change. Users can add the `noCleanup` function at the new field of `StateMachine` to have it work as before.