### PR TITLE
fix Mock in parallel

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -125,6 +125,7 @@ test-suite quickcheck-state-machine-test
                        ErrorEncountered,
                        Hanoi,
                        MemoryReference,
+                       Mock,
                        Overflow,
                        ProcessRegistry,
                        ShrinkingProps,

--- a/test/Mock.hs
+++ b/test/Mock.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE ExplicitNamespaces   #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE MonoLocalBinds       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Mock
+    ( prop_sequential_mock
+    , prop_parallel_mock
+    , prop_nparallel_mock
+    )
+    where
+
+import           Control.Concurrent
+import           Control.Monad.IO.Class
+                   (liftIO)
+import           GHC.Generics
+                   (Generic, Generic1)
+import           Prelude
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+                   (monadicIO)
+import           Test.StateMachine
+import           Test.StateMachine.DotDrawing
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+
+data Command r
+  = Create
+  deriving (Eq, Generic1, Rank2.Functor, Rank2.Foldable, Rank2.Traversable, CommandNames)
+
+deriving instance Show (Command Symbolic)
+deriving instance Read (Command Symbolic)
+deriving instance Show (Command Concrete)
+
+data Response r
+  = Created (Reference Int r)
+  | NotCreated
+  deriving (Eq, Generic1, Rank2.Foldable)
+
+deriving instance Show (Response Symbolic)
+deriving instance Read (Response Symbolic)
+deriving instance Show (Response Concrete)
+
+data Model r = Model {
+      refs :: [Reference Int r]
+    , c    :: Int
+    }
+  deriving (Generic, Show)
+
+instance ToExpr (Model Symbolic)
+instance ToExpr (Model Concrete)
+
+initModel :: Model r
+initModel = Model [] 0
+
+transition :: Model r -> Command r -> Response r -> Model r
+transition m@Model{..} cmd resp = case (cmd, resp, c) of
+  (Create, Created ref, 0) -> Model (ref : refs) 1
+  (Create, _, _)           -> m
+
+precondition :: Model Symbolic -> Command Symbolic -> Logic
+precondition _ cmd = case cmd of
+    Create        -> Top
+
+postcondition :: Model Concrete -> Command Concrete -> Response Concrete -> Logic
+postcondition _ _ _ = Top
+
+semantics :: MVar Int -> Command Concrete -> IO (Response Concrete)
+semantics counter cmd = case cmd of
+  Create        -> do
+    c <- modifyMVar counter (\x -> return (x + 1, x))
+    case c of
+        0 -> return $ Created $ reference c
+        _ -> return NotCreated
+
+mock :: Model Symbolic -> Command Symbolic -> GenSym (Response Symbolic)
+mock Model{..} cmd = case (cmd, c) of
+  (Create, 0) -> Created   <$> genSym
+  (Create, _) -> return NotCreated
+
+generator :: Model Symbolic -> Maybe (Gen (Command Symbolic))
+generator _            = Just $ frequency
+    [(1, return Create)]
+
+shrinker :: Model Symbolic -> Command Symbolic -> [Command Symbolic]
+shrinker _ _ = []
+
+sm :: MVar Int ->  StateMachine Model Command IO Response
+sm counter = StateMachine initModel transition precondition postcondition
+        Nothing generator shrinker (semantics counter) mock noCleanup
+
+smUnused :: StateMachine Model Command IO Response
+smUnused = sm undefined
+
+prop_sequential_mock :: Property
+prop_sequential_mock = forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
+  counter <- liftIO $ newMVar 0
+  (hist, _model, res) <- runCommands (sm counter) cmds
+  prettyCommands smUnused hist (res === Ok)
+
+prop_parallel_mock :: Property
+prop_parallel_mock = forAllParallelCommands smUnused $ \cmds -> monadicIO $ do
+    counter <- liftIO $ newMVar 0
+    ret <- runParallelCommandsNTimes 1 (sm counter) cmds
+    prettyParallelCommandsWithOpts cmds opts ret
+      where opts = Just $ GraphOptions "mock.png" Png
+
+prop_nparallel_mock :: Property
+prop_nparallel_mock = forAllNParallelCommands smUnused 3 $ \cmds -> monadicIO $ do
+    counter <- liftIO $ newMVar 0
+    ret <- runNParallelCommandsNTimes 1 (sm counter) cmds
+    prettyNParallelCommandsWithOpts cmds opts ret
+      where opts = Just $ GraphOptions "mock-np.png" Png

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,6 +28,7 @@ import           Echo
 import           ErrorEncountered
 import           Hanoi
 import           MemoryReference
+import           Mock
 import           Overflow
 import           ProcessRegistry
 import qualified ShrinkingProps
@@ -154,6 +155,11 @@ tests docker0 = testGroup "Tests"
       , testProperty "4-ParallelWithExclusiveLock" (prop_ticketDispenserNParallelOK 4)
       , testProperty "3-ParallelWithSharedLock" (expectFailure $
                                                     prop_ticketDispenserNParallelBad 3)
+      ]
+  , testGroup "Mock"
+      [ testProperty "sequential" prop_sequential_mock
+      , testProperty "parallel"   prop_parallel_mock
+      , testProperty "nparallel"  prop_nparallel_mock
       ]
   , testGroup "CircularBuffer"
       [ testProperty "unpropNoSizeCheck"


### PR DESCRIPTION
This pr fixes what I think is an issue related to the mock function in the parallel case. It also adds a new example, which fails without the fix. The test is pretty simple: we model a system from which you can only try to create some references:
```
data Command r
  = Create
```
The system manages to create only the first reference:
```
data Response r
  = Created (Reference Int r)
  | NotCreated
```
The sequential case works well, but in the paralle case if two commands try to create a reference in parallel, like in the example below, we don't know which one will succeed.
```
      ParallelCommands
        { prefix = Commands { unCommands = [] }
        , suffixes =
            [ Pair
                { proj1 =
                    Commands
                      { unCommands =
                          [ Command Create (Created (Reference (Symbolic (Var 0)))) [ Var 0 ]
                          ]
                      }
                , proj2 =
                    Commands { unCommands = [ Command Create NotCreated [] ] }
                }
            ]
        }
```
This can result in a mismatch between the references of the Symbolic Responses and the concrete, which results in `MockSemanticsMismatch` error, because the execution cannot update the `Environment`. Not sure what the best fix is: In my fix I added an additional check in `parallelSafe`, which makes sure that in all permutations, the mocked responses return the same number of Vars.
