### PR TITLE
High-level interface to the state machine API

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -34,6 +34,9 @@ library
                      , Test.StateMachine.ConstructorName
                      , Test.StateMachine.DotDrawing
                      , Test.StateMachine.Labelling
+                     , Test.StateMachine.Lockstep.Aux
+                     , Test.StateMachine.Lockstep.NAry
+                     , Test.StateMachine.Lockstep.Simple
                      , Test.StateMachine.Logic
                      , Test.StateMachine.Markov
                      , Test.StateMachine.Parallel
@@ -65,6 +68,7 @@ library
         process >=1.2.0.0,
         QuickCheck >=2.13.2,
         random >=1.1,
+        sop-core,
         split,
         text,
         tree-diff >=0.0.2.1,
@@ -133,6 +137,7 @@ test-suite quickcheck-state-machine-test
                        Echo,
                        ErrorEncountered,
                        Hanoi,
+                       IORefs,
                        MemoryReference,
                        Mock,
                        Overflow,

--- a/src/Test/StateMachine/Lockstep/Aux.hs
+++ b/src/Test/StateMachine/Lockstep/Aux.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.StateMachine.Lockstep.Aux (
+    Elem(..)
+  , npAt
+  , NTraversable(..)
+  , ntraverse
+  , ncfmap
+  , nfmap
+  , ncfoldMap
+  , nfoldMap
+  ) where
+
+import Prelude
+import Control.Monad.State
+import Data.Kind (Type)
+import Data.Monoid (Monoid)
+import Data.Proxy
+import Data.SOP
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+-- TODO: Could simulate by using @NS xs (K ())@
+data Elem (xs :: [k]) (a :: k) where
+  ElemHead :: Elem (k ': ks) k
+  ElemTail :: Elem ks k -> Elem (k' ': ks) k
+
+npAt' :: Elem xs a -> NP f xs -> f a
+npAt' ElemHead      (f :* _)  = f
+npAt' (ElemTail ix) (_ :* fs) = npAt' ix fs
+
+npAt :: NP f xs -> Elem xs a -> f a
+npAt = flip npAt'
+
+-- | N-ary traversable functors
+--
+-- TODO: Don't provide Elem explicitly (just instantiate @c@)?
+-- TODO: Introduce HTraverse into SOP?
+class NTraversable (f :: (k -> Type) -> [k] -> Type) where
+  nctraverse :: (Applicative m, All c xs)
+             => proxy c
+             -> (forall a. c a => Elem xs a -> g a -> m (h a))
+             -> f g xs -> m (f h xs)
+
+ntraverse :: (NTraversable f, Applicative m, SListI xs)
+          => (forall a. Elem xs a -> g a -> m (h a))
+          -> f g xs -> m (f h xs)
+ntraverse = nctraverse (Proxy @Top)
+
+ncfmap :: (NTraversable f, All c xs)
+       => proxy c
+       -> (forall a. c a => Elem xs a -> g a -> h a)
+       -> f g xs -> f h xs
+ncfmap p f xs = unI $ nctraverse p (\ix -> I . f ix) xs
+
+nfmap :: (NTraversable f, SListI xs)
+      => (forall a. Elem xs a -> g a -> h a)
+      -> f g xs -> f h xs
+nfmap f xs = ncfmap (Proxy @Top) f xs
+
+ncfoldMap :: forall proxy f g m c xs.
+             (NTraversable f, Monoid m, All c xs)
+          => proxy c
+          -> (forall a. c a => Elem xs a -> g a -> m)
+          -> f g xs -> m
+ncfoldMap p f = \xs -> execState (aux xs) mempty
+  where
+    aux :: f g xs -> State m (f g xs)
+    aux xs = nctraverse p aux' xs
+
+    aux' :: c a => Elem xs a -> g a -> State m (g a)
+    aux' ix ga = modify (f ix ga `mappend`) >> return ga
+
+nfoldMap :: (NTraversable f, Monoid m, SListI xs)
+         => (forall a. Elem xs a -> g a -> m)
+         -> f g xs -> m
+nfoldMap f xs = ncfoldMap (Proxy @Top) f xs

--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -1,0 +1,407 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+module Test.StateMachine.Lockstep.NAry (
+    -- * Test type-level parameters
+    MockState
+  , Cmd
+  , Resp
+  , RealHandles
+  , MockHandle
+  , RealMonad
+  , Test
+    -- * Test term-level parameters
+  , StateMachineTest(..)
+    -- * Handle instantiation
+  , At(..)
+  , (:@)
+    -- * Model state
+  , Model(..)
+  , Refs(..)
+  , Refss(..)
+  , FlipRef(..)
+    -- * Running the tests
+  , prop_sequential
+  , prop_parallel
+  ) where
+
+import Prelude
+import Data.Functor.Classes
+import Data.Kind (Type)
+import Data.Maybe (fromJust)
+import Data.SOP
+import Data.Typeable
+import GHC.Generics (Generic)
+import Test.QuickCheck
+import Test.QuickCheck.Monadic
+import Test.StateMachine
+
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup (Semigroup(..))
+#endif
+
+import qualified Data.Monoid                   as M
+import qualified Data.TreeDiff                 as TD
+import qualified Test.StateMachine.Types       as QSM
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+import Test.StateMachine.Lockstep.Aux
+
+{-------------------------------------------------------------------------------
+  Test type-level parameters
+-------------------------------------------------------------------------------}
+
+type family MockState   t   :: Type
+data family Cmd         t   :: (Type -> Type) -> [Type] -> Type
+data family Resp        t   :: (Type -> Type) -> [Type] -> Type
+type family RealHandles t   :: [Type]
+data family MockHandle  t a :: Type
+type family RealMonad   t   :: Type -> Type
+
+{-------------------------------------------------------------------------------
+  Reference environments
+-------------------------------------------------------------------------------}
+
+-- | Relation between real and mock references for single handle type @a@
+newtype Refs t r a = Refs { unRefs :: [(Reference a r, MockHandle t a)] }
+  deriving (Semigroup, Monoid, Generic)
+
+deriving instance (Show1 r, Show a, Show (MockHandle t a)) => Show (Refs t r a)
+deriving instance (ToExpr a, ToExpr (MockHandle t a)) => ToExpr (Refs t Concrete a)
+
+-- | Relation between real and mock references for /all/ handle types
+newtype Refss t r = Refss { unRefss :: NP (Refs t r) (RealHandles t) }
+
+instance ( Show1 r
+         , All (And Show (Compose Show (MockHandle t))) (RealHandles t)
+         ) => Show (Refss t r) where
+  show = unlines
+       . hcollapse
+       . hcmap (Proxy @(And Show (Compose Show (MockHandle t)))) showOne
+       . unRefss
+    where
+      showOne :: (Show a, Show (MockHandle t a))
+              => Refs t r a -> K String a
+      showOne = K . show
+
+instance All (And ToExpr (Compose ToExpr (MockHandle t))) (RealHandles t)
+      => ToExpr (Refss t Concrete) where
+  toExpr = TD.Lst
+         . hcollapse
+         . hcmap (Proxy @(And ToExpr (Compose ToExpr (MockHandle t)))) toExprOne
+         . unRefss
+    where
+      toExprOne :: (ToExpr a, ToExpr (MockHandle t a))
+                => Refs t Concrete a -> K (TD.Expr) a
+      toExprOne = K . toExpr
+
+instance SListI (RealHandles t) => Semigroup (Refss t r) where
+  Refss rss <> Refss rss' = Refss $ hzipWith (<>) rss rss'
+
+instance SListI (RealHandles t) => Monoid (Refss t r) where
+  mempty = Refss $ hpure (Refs mempty)
+
+{-------------------------------------------------------------------------------
+  Default instantiation to handles
+-------------------------------------------------------------------------------}
+
+type family Test (f :: (Type -> Type) -> [Type] -> Type) :: Type where
+  Test (Cmd  t) = t
+  Test (Resp t) = t
+
+newtype FlipRef r h = FlipRef { unFlipRef :: Reference h r }
+  deriving (Show)
+
+-- @f@ will be instantiated with @Cmd@ or @Resp@
+-- @r@ will be instantiated with 'Symbolic' or 'Concrete'
+newtype At f r = At { unAt :: f (FlipRef r) (RealHandles (Test f)) }
+type    f :@ r = At f r
+
+deriving instance (Show (f (FlipRef r) (RealHandles (Test f)))) => Show (At f r)
+
+{-------------------------------------------------------------------------------
+  Model
+-------------------------------------------------------------------------------}
+
+data Model t r = Model {
+      modelState :: MockState t
+    , modelRefss :: Refss t r
+    }
+  deriving (Generic)
+
+deriving instance ( Show1 r
+                  , Show (MockState t)
+                  , All (And Show (Compose Show (MockHandle t))) (RealHandles t)
+                  ) => Show (Model t r)
+
+instance ( ToExpr (MockState t)
+         , All (And ToExpr (Compose ToExpr (MockHandle t))) (RealHandles t)
+         ) => ToExpr (Model t Concrete)
+
+initModel :: StateMachineTest t -> Model t r
+initModel StateMachineTest{..} = Model initMock (Refss (hpure (Refs [])))
+
+{-------------------------------------------------------------------------------
+  High level API
+-------------------------------------------------------------------------------}
+
+data StateMachineTest t =
+    ( Monad (RealMonad t)
+    -- Requirements on the handles
+    , All Typeable                                     (RealHandles t)
+    , All Eq                                           (RealHandles t)
+    , All (And Show   (Compose Show   (MockHandle t))) (RealHandles t)
+    , All (And ToExpr (Compose ToExpr (MockHandle t))) (RealHandles t)
+    -- Response
+    , NTraversable (Resp t)
+    , Eq   (Resp t (MockHandle t)     (RealHandles t))
+    , Show (Resp t (MockHandle t)     (RealHandles t))
+    , Show (Resp t (FlipRef Symbolic) (RealHandles t))
+    , Show (Resp t (FlipRef Concrete) (RealHandles t))
+    -- Command
+    , NTraversable (Cmd t)
+    , Show (Cmd t (FlipRef Symbolic) (RealHandles t))
+    , Show (Cmd t (FlipRef Concrete) (RealHandles t))
+    -- MockState
+    , Show   (MockState t)
+    , ToExpr (MockState t)
+    ) => StateMachineTest {
+      runMock    :: Cmd t (MockHandle t) (RealHandles t) -> MockState t -> (Resp t (MockHandle t) (RealHandles t), MockState t)
+    , runReal    :: Cmd t I              (RealHandles t) -> RealMonad t (Resp t I (RealHandles t))
+    , initMock   :: MockState t
+    , newHandles :: forall f. Resp t f (RealHandles t) -> NP ([] :.: f) (RealHandles t)
+    , generator  :: Model t Symbolic -> Maybe (Gen (Cmd t :@ Symbolic))
+    , shrinker   :: Model t Symbolic -> Cmd t :@ Symbolic -> [Cmd t :@ Symbolic]
+    , cleanup    :: Model t Concrete -> RealMonad t ()
+    }
+
+semantics :: StateMachineTest t
+          -> Cmd t :@ Concrete
+          -> RealMonad t (Resp t :@ Concrete)
+semantics StateMachineTest{..} (At c) =
+    (At . ncfmap (Proxy @Typeable) (const wrapConcrete)) <$>
+      runReal (nfmap (const unwrapConcrete) c)
+
+unwrapConcrete :: FlipRef Concrete a -> I a
+unwrapConcrete = I . concrete . unFlipRef
+
+wrapConcrete :: Typeable a => I a -> FlipRef Concrete a
+wrapConcrete = FlipRef . reference  . unI
+
+-- | Turn @Cmd@ or @Resp@ in terms of (symbolic or concrete) references to
+-- real handles into a command in terms of mock handles.
+--
+-- This is isomorphic to
+--
+-- > toMock :: Refss t Symbolic
+--          -> Cmd (FlipRef r) (Handles t)
+--          -> Cmd  ToMock     (Handles t)
+toMockHandles :: (NTraversable f, t ~ Test f, All Eq (RealHandles t), Eq1 r)
+              => Refss t r -> f :@ r -> f (MockHandle t) (RealHandles t)
+toMockHandles rss (At fr) =
+    ncfmap (Proxy @Eq) (\pf -> find (unRefss rss) pf . unFlipRef) fr
+  where
+    find :: (Eq a, Eq1 r)
+         => NP (Refs t r) (RealHandles t)
+         -> Elem (RealHandles t) a
+         -> Reference a r -> MockHandle t a
+    find refss ix r = unRefs (npAt refss ix) ! r
+
+step :: Eq1 r
+     => StateMachineTest t
+     -> Model t r
+     -> Cmd t :@ r
+     -> (Resp t (MockHandle t) (RealHandles t), MockState t)
+step StateMachineTest{..} (Model st rss) cmd =
+    runMock (toMockHandles rss cmd) st
+
+data Event t r = Event {
+      before   :: Model t    r
+    , cmd      :: Cmd   t :@ r
+    , after    :: Model t    r
+    , mockResp :: Resp t (MockHandle t) (RealHandles t)
+    }
+
+lockstep :: forall t r. Eq1 r
+         => StateMachineTest t
+         -> Model t    r
+         -> Cmd   t :@ r
+         -> Resp  t :@ r
+         -> Event t    r
+lockstep sm@StateMachineTest{..} m@(Model _ rss) c (At resp) = Event {
+      before   = m
+    , cmd      = c
+    , after    = Model st' (rss <> rss')
+    , mockResp = resp'
+    }
+  where
+    (resp', st') = step sm m c
+
+    rss' :: Refss t r
+    rss' = zipHandles (newHandles resp) (newHandles resp')
+
+transition :: Eq1 r
+           => StateMachineTest t
+           -> Model t    r
+           -> Cmd   t :@ r
+           -> Resp  t :@ r
+           -> Model t    r
+transition sm m c = after . lockstep sm m c
+
+postcondition :: StateMachineTest t
+              -> Model t    Concrete
+              -> Cmd   t :@ Concrete
+              -> Resp  t :@ Concrete
+              -> Logic
+postcondition sm@StateMachineTest{} m c r =
+    toMockHandles (modelRefss $ after e) r .== mockResp e
+  where
+    e = lockstep sm m c r
+
+symbolicResp :: StateMachineTest t
+             -> Model t Symbolic
+             -> Cmd t :@ Symbolic
+             -> GenSym (Resp t :@ Symbolic)
+symbolicResp sm@StateMachineTest{} m c =
+    At <$> nctraverse (Proxy @Typeable) (\_ _ -> FlipRef <$> genSym) resp
+  where
+    (resp, _mock') = step sm m c
+
+precondition :: forall t. (NTraversable (Cmd t), All Eq (RealHandles t))
+             => Model t Symbolic
+             -> Cmd t :@ Symbolic
+             -> Logic
+precondition (Model _ (Refss hs)) (At c) =
+    Boolean (M.getAll $ nfoldMap check c) .// "No undefined handles"
+  where
+    check :: Elem (RealHandles t) a -> FlipRef Symbolic a -> M.All
+    check ix (FlipRef a) = M.All $ any (sameRef a) $ map fst (unRefs (hs `npAt` ix))
+
+    -- TODO: Patch QSM
+    sameRef :: Reference a Symbolic -> Reference a Symbolic -> Bool
+    sameRef (QSM.Reference (QSM.Symbolic v)) (QSM.Reference (QSM.Symbolic v')) = v == v'
+
+toStateMachine :: StateMachineTest t
+               -> StateMachine (Model t) (At (Cmd t)) (RealMonad t) (At (Resp t))
+toStateMachine sm@StateMachineTest{} = StateMachine {
+      initModel     = initModel     sm
+    , transition    = transition    sm
+    , precondition  = precondition
+    , postcondition = postcondition sm
+    , generator     = generator     sm
+    , shrinker      = shrinker      sm
+    , semantics     = semantics     sm
+    , mock          = symbolicResp  sm
+    , cleanup       = cleanup       sm
+    , invariant     = Nothing
+    }
+
+prop_sequential :: RealMonad t ~ IO
+                => StateMachineTest t
+                -> Maybe Int   -- ^ (Optional) minimum number of commands
+                -> Property
+prop_sequential sm@StateMachineTest{} mMinSize =
+    forAllCommands sm' mMinSize $ \cmds ->
+      monadicIO $ do
+        (hist, _model, res) <- runCommands sm' cmds
+        prettyCommands sm' hist
+          $ res === Ok
+  where
+    sm' = toStateMachine sm
+
+prop_parallel :: RealMonad t ~ IO
+              => StateMachineTest t
+              -> Maybe Int   -- ^ (Optional) minimum number of commands
+              -> Property
+prop_parallel sm@StateMachineTest{} mMinSize =
+    forAllParallelCommands sm' mMinSize $ \cmds ->
+      monadicIO $
+            prettyParallelCommands cmds
+        =<< runParallelCommands sm' cmds
+  where
+    sm' = toStateMachine sm
+
+{-------------------------------------------------------------------------------
+  Rank2 instances
+-------------------------------------------------------------------------------}
+
+instance (NTraversable (Cmd t), SListI (RealHandles t))
+      => Rank2.Functor (At (Cmd t)) where
+  fmap :: forall p q. (forall a. p a -> q a) -> At (Cmd t) p -> At (Cmd t) q
+  fmap f (At cmd) = At $ nfmap (const f') cmd
+    where
+      f' :: FlipRef p a -> FlipRef q a
+      f' = FlipRef . Rank2.fmap f . unFlipRef
+
+instance (NTraversable (Cmd t), SListI (RealHandles t))
+      => Rank2.Foldable (At (Cmd t)) where
+  foldMap :: forall p m. Monoid m => (forall a. p a -> m) -> At (Cmd t) p -> m
+  foldMap f (At cmd) = nfoldMap (const f') cmd
+    where
+      f' :: FlipRef p a -> m
+      f' = Rank2.foldMap f . unFlipRef
+
+instance (NTraversable (Cmd t), SListI (RealHandles t))
+      => Rank2.Traversable (At (Cmd t)) where
+  traverse :: forall f p q. Applicative f
+           => (forall a. p a -> f (q a)) -> At (Cmd t) p -> f (At (Cmd t) q)
+  traverse f (At cmd) = At <$> ntraverse (const f') cmd
+    where
+      f' :: FlipRef p a -> f (FlipRef q a)
+      f' = fmap FlipRef . Rank2.traverse f . unFlipRef
+
+instance (NTraversable (Resp t), SListI (RealHandles t))
+      => Rank2.Functor (At (Resp t)) where
+  fmap :: forall p q. (forall a. p a -> q a) -> At (Resp t) p -> At (Resp t) q
+  fmap f (At cmd) = At $ nfmap (const f') cmd
+    where
+      f' :: FlipRef p a -> FlipRef q a
+      f' = FlipRef . Rank2.fmap f . unFlipRef
+
+instance (NTraversable (Resp t), SListI (RealHandles t))
+      => Rank2.Foldable (At (Resp t)) where
+  foldMap :: forall p m. Monoid m => (forall a. p a -> m) -> At (Resp t) p -> m
+  foldMap f (At cmd) = nfoldMap (const f') cmd
+    where
+      f' :: FlipRef p a -> m
+      f' = Rank2.foldMap f . unFlipRef
+
+instance (NTraversable (Resp t), SListI (RealHandles t))
+      => Rank2.Traversable (At (Resp t)) where
+  traverse :: forall f p q. Applicative f
+           => (forall a. p a -> f (q a)) -> At (Resp t) p -> f (At (Resp t) q)
+  traverse f (At cmd) = At <$> ntraverse (const f') cmd
+    where
+      f' :: FlipRef p a -> f (FlipRef q a)
+      f' = fmap FlipRef . Rank2.traverse f . unFlipRef
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+(!) :: Eq k => [(k, a)] -> k -> a
+env ! r = fromJust (lookup r env)
+
+zipHandles :: SListI (RealHandles t)
+           => NP ([] :.: FlipRef r)    (RealHandles t)
+           -> NP ([] :.: MockHandle t) (RealHandles t)
+           -> Refss t r
+zipHandles = \real mock -> Refss $ hzipWith zip' real mock
+  where
+    zip' :: (:.:) [] (FlipRef r) a -> (:.:) [] (MockHandle t) a -> Refs t r a
+    zip' (Comp real) (Comp mock) = Refs $ zip (map unFlipRef real) mock

--- a/src/Test/StateMachine/Lockstep/Simple.hs
+++ b/src/Test/StateMachine/Lockstep/Simple.hs
@@ -1,0 +1,234 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.StateMachine.Lockstep.Simple (
+    -- * Test type-level parameters
+    MockState
+  , Cmd
+  , Resp
+  , RealHandle
+  , MockHandle
+  , Test
+    -- * Test term-level parameters
+  , StateMachineTest(..)
+    -- * Handle instantiation
+  , At(..)
+  , (:@)
+    -- * Model state
+  , Model(..)
+    -- * Running the tests
+  , prop_sequential
+  , prop_parallel
+    -- * Translate to n-ary model model
+  , fromSimple
+  ) where
+
+import Prelude
+import Data.Bifunctor
+import Data.Functor.Classes
+import Data.Kind (Type)
+import Data.SOP
+import Data.Typeable
+import Test.QuickCheck
+import Test.StateMachine
+import Test.StateMachine.Lockstep.Aux
+import Test.StateMachine.Lockstep.NAry (MockState)
+
+import qualified Test.StateMachine.Lockstep.NAry as NAry
+
+{-------------------------------------------------------------------------------
+  Top-level parameters
+-------------------------------------------------------------------------------}
+
+data family Cmd        t :: Type -> Type
+data family Resp       t :: Type -> Type
+data family RealHandle t :: Type
+data family MockHandle t :: Type
+
+{-------------------------------------------------------------------------------
+  Default handle instantiation
+-------------------------------------------------------------------------------}
+
+type family Test (f :: Type -> Type) :: Type where
+  Test (Cmd  t) = t
+  Test (Resp t) = t
+
+-- @f@ will be instantiated with @Cmd@ or @Resp@
+-- @r@ will be instantiated with 'Symbolic' or 'Concrete'
+newtype At f r = At { unAt :: f (Reference (RealHandle (Test f)) r) }
+type    f :@ r = At f r
+
+{-------------------------------------------------------------------------------
+  Simplified model
+-------------------------------------------------------------------------------}
+
+data Model t r = Model {
+      modelState :: MockState t
+    , modelRefs  :: [(Reference (RealHandle t) r, MockHandle t)]
+    }
+
+modelToSimple :: NAry.Model (Simple t) r -> Model t r
+modelToSimple NAry.Model{modelRefss = NAry.Refss (NAry.Refs rs :* Nil), ..} = Model {
+      modelState = modelState
+    , modelRefs  = map (second unSimpleToMock) rs
+    }
+
+{-------------------------------------------------------------------------------
+  Wrap and unwrap
+-------------------------------------------------------------------------------}
+
+cmdAtFromSimple :: Functor (Cmd t)
+                => Cmd t :@ Symbolic -> NAry.Cmd (Simple t) NAry.:@ Symbolic
+cmdAtFromSimple = NAry.At . SimpleCmd . fmap NAry.FlipRef . unAt
+
+cmdAtToSimple :: Functor (Cmd t)
+              => NAry.Cmd (Simple t) NAry.:@ Symbolic -> Cmd t :@ Symbolic
+cmdAtToSimple = At . fmap (NAry.unFlipRef) . unSimpleCmd . NAry.unAt
+
+cmdMockToSimple :: Functor (Cmd t)
+                => NAry.Cmd (Simple t) (NAry.MockHandle (Simple t)) '[RealHandle t]
+                -> Cmd t (MockHandle t)
+cmdMockToSimple = fmap unSimpleToMock . unSimpleCmd
+
+cmdRealToSimple :: Functor (Cmd t)
+                => NAry.Cmd (Simple t) I '[RealHandle t]
+                -> Cmd t (RealHandle t)
+cmdRealToSimple = fmap unI . unSimpleCmd
+
+respMockFromSimple :: Functor (Resp t)
+                   => Resp t (MockHandle t)
+                   -> NAry.Resp (Simple t) (NAry.MockHandle (Simple t)) '[RealHandle t]
+respMockFromSimple = SimpleResp . fmap SimpleToMock
+
+respRealFromSimple :: Functor (Resp t)
+                   => Resp t (RealHandle t)
+                   -> NAry.Resp (Simple t) I '[RealHandle t]
+respRealFromSimple = SimpleResp . fmap I
+
+{-------------------------------------------------------------------------------
+  User defined values
+-------------------------------------------------------------------------------}
+
+data StateMachineTest t =
+    ( Typeable t
+      -- Response
+    , Eq   (Resp t (MockHandle t))
+    , Show (Resp t (Reference (RealHandle t) Symbolic))
+    , Show (Resp t (Reference (RealHandle t) Concrete))
+    , Show (Resp t (MockHandle t))
+    , Traversable (Resp t)
+      -- Command
+    , Show (Cmd t (Reference (RealHandle t) Symbolic))
+    , Show (Cmd t (Reference (RealHandle t) Concrete))
+    , Traversable (Cmd t)
+      -- Real handles
+    , Eq     (RealHandle t)
+    , Show   (RealHandle t)
+    , ToExpr (RealHandle t)
+      -- Mock handles
+    , Eq     (MockHandle t)
+    , Show   (MockHandle t)
+    , ToExpr (MockHandle t)
+      -- Mock state
+    , Show   (MockState t)
+    , ToExpr (MockState t)
+    ) => StateMachineTest {
+      runMock    :: Cmd t (MockHandle t) -> MockState t -> (Resp t (MockHandle t), MockState t)
+    , runReal    :: Cmd t (RealHandle t) -> IO (Resp t (RealHandle t))
+    , initMock   :: MockState t
+    , newHandles :: forall h. Resp t h -> [h]
+    , generator  :: Model t Symbolic -> Maybe (Gen (Cmd t :@ Symbolic))
+    , shrinker   :: Model t Symbolic -> Cmd t :@ Symbolic -> [Cmd t :@ Symbolic]
+    , cleanup    :: Model t Concrete -> IO ()
+    }
+
+data Simple t
+
+type instance NAry.MockState   (Simple t) = MockState t
+type instance NAry.RealHandles (Simple t) = '[RealHandle t]
+type instance NAry.RealMonad   (Simple _) = IO
+
+data instance NAry.Cmd (Simple _) _f _hs where
+    SimpleCmd :: Cmd t (f h) -> NAry.Cmd (Simple t) f '[h]
+
+data instance NAry.Resp (Simple _) _f _hs where
+    SimpleResp :: Resp t (f h) -> NAry.Resp (Simple t) f '[h]
+
+newtype instance NAry.MockHandle (Simple t) (RealHandle t) =
+    SimpleToMock { unSimpleToMock :: MockHandle t }
+
+unSimpleCmd :: NAry.Cmd (Simple t) f '[h] -> Cmd t (f h)
+unSimpleCmd (SimpleCmd cmd) = cmd
+
+unSimpleResp :: NAry.Resp (Simple t) f '[h] -> Resp t (f h)
+unSimpleResp (SimpleResp resp) = resp
+
+instance ( Functor (Resp t)
+         , Eq (Resp t (MockHandle t))
+         , Eq (MockHandle t)
+         ) => Eq (NAry.Resp (Simple t) (NAry.MockHandle (Simple t)) '[RealHandle t]) where
+  SimpleResp r == SimpleResp r' = (unSimpleToMock <$> r) == (unSimpleToMock <$> r')
+
+instance ( Functor (Resp t)
+         , Show (Resp t (MockHandle t))
+         ) => Show (NAry.Resp (Simple t) (NAry.MockHandle (Simple t)) '[RealHandle t]) where
+  show (SimpleResp r) = show (unSimpleToMock <$> r)
+
+instance ( Functor (Resp t)
+         , Show (Resp t (Reference (RealHandle t) r))
+         , Show1 r
+         ) => Show (NAry.Resp (Simple t) (NAry.FlipRef r) '[RealHandle t]) where
+  show (SimpleResp r) = show (NAry.unFlipRef <$> r)
+
+instance ( Functor (Cmd t)
+         , Show (Cmd t (Reference (RealHandle t) r))
+         , Show1 r
+         ) => Show (NAry.Cmd (Simple t) (NAry.FlipRef r) '[RealHandle t]) where
+  show (SimpleCmd r) = show (NAry.unFlipRef <$> r)
+
+deriving instance Eq   (MockHandle t) => Eq   (NAry.MockHandle (Simple t) (RealHandle t))
+deriving instance Show (MockHandle t) => Show (NAry.MockHandle (Simple t) (RealHandle t))
+
+instance Traversable (Resp t) => NTraversable (NAry.Resp (Simple t)) where
+  nctraverse _ f (SimpleResp x) = SimpleResp <$> traverse (f ElemHead) x
+
+instance Traversable (Cmd t) => NTraversable (NAry.Cmd (Simple t)) where
+  nctraverse _ f (SimpleCmd x) = SimpleCmd <$> traverse (f ElemHead) x
+
+instance ToExpr (MockHandle t)
+      => ToExpr (NAry.MockHandle (Simple t) (RealHandle t)) where
+  toExpr (SimpleToMock h) = toExpr h
+
+fromSimple :: StateMachineTest t -> NAry.StateMachineTest (Simple t)
+fromSimple StateMachineTest{..} = NAry.StateMachineTest {
+      runMock    = \cmd st -> first respMockFromSimple (runMock (cmdMockToSimple cmd) st)
+    , runReal    = \cmd -> respRealFromSimple <$> (runReal (cmdRealToSimple cmd))
+    , initMock   = initMock
+    , newHandles = \r -> Comp (newHandles (unSimpleResp r)) :* Nil
+    , generator  = \m     -> fmap cmdAtFromSimple <$> generator (modelToSimple m)
+    , shrinker   = \m cmd ->      cmdAtFromSimple <$> shrinker  (modelToSimple m) (cmdAtToSimple cmd)
+    , cleanup    = cleanup   . modelToSimple
+    }
+
+{-------------------------------------------------------------------------------
+  Running the tests
+-------------------------------------------------------------------------------}
+
+prop_sequential :: StateMachineTest t
+                -> Maybe Int   -- ^ (Optional) minimum number of commands
+                -> Property
+prop_sequential = NAry.prop_sequential . fromSimple
+
+prop_parallel :: StateMachineTest t
+              -> Maybe Int   -- ^ (Optional) minimum number of commands
+              -> Property
+prop_parallel = NAry.prop_parallel . fromSimple

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - tree-diff-0.0.2.1@sha256:4bd07bd26091f21710288c1037124bfe19aadb5bdf3df57c8374afaa5f14fef8
   - graphviz-2999.20.0.3
   - hs-rqlite-0.1.2.0
+  - sop-core-0.5.0.0
 allow-newer: true
 nix:
   enable: false

--- a/test/IORefs.hs
+++ b/test/IORefs.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE DeriveFoldable      #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module IORefs (prop_IORefs_sequential) where
+
+import Prelude
+import Control.Concurrent
+import Data.Coerce (coerce)
+import Data.Foldable (toList)
+import Data.IORef
+import Data.Map.Strict (Map)
+import GHC.Generics (Generic)
+import Test.QuickCheck
+import Test.StateMachine
+
+import qualified Data.Map.Strict as Map
+
+import Test.StateMachine.Lockstep.Simple
+
+{-------------------------------------------------------------------------------
+  Instantiate the simple API
+-------------------------------------------------------------------------------}
+
+data T a
+
+data instance Cmd (T _) h = New | Read h | Update h
+  deriving (Show, Functor, Foldable, Traversable)
+
+data instance Resp (T a) h = Var h | Val a | Unit ()
+  deriving (Show, Eq, Functor, Foldable, Traversable)
+
+data instance MockHandle (T _) = MV Int
+  deriving (Show, Eq, Ord, Generic)
+
+newtype instance RealHandle (T a) = RealVar (Opaque (IORef a))
+  deriving (Eq, Show, Generic)
+
+type instance MockState (T a) = Map (MockHandle (T a)) a
+
+instance ToExpr (MockHandle (T a))
+instance ToExpr (RealHandle (T a))
+
+{-------------------------------------------------------------------------------
+  Interpreters
+-------------------------------------------------------------------------------}
+
+runMock :: a
+        -> (a -> a)
+        -> Cmd (T a) (MockHandle (T a))
+        -> MockState (T a) -> (Resp (T a) (MockHandle (T a)), MockState (T a))
+runMock e f cmd m =
+    case cmd of
+      New      -> let v = MV (Map.size m) in (Var v, Map.insert v e m)
+      Read   v -> (Val (m Map.! v), m)
+      Update v -> (Unit (), Map.adjust f v m)
+
+runReal :: a
+        -> (a -> a)
+        -> Cmd (T a) (RealHandle (T a))
+        -> IO (Resp (T a) (RealHandle (T a)))
+runReal e f cmd =
+    case cmd of
+      New      -> Var  <$> coerce <$> newIORef e
+      Read   r -> Val  <$> readIORef  (coerce r)
+      Update r -> Unit <$> slowModify (coerce r) f
+
+slowModify :: IORef a -> (a -> a) -> IO ()
+slowModify r f = readIORef r >>= \a -> threadDelay 1000 >> writeIORef r (f a)
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+generator :: forall a.
+             Model (T a) Symbolic
+          -> Maybe (Gen (Cmd (T a) :@ Symbolic))
+generator (Model _ hs) = Just $ oneof $ concat [
+      withoutHandle
+    , if null hs then [] else withHandle
+    ]
+  where
+    withoutHandle :: [Gen (Cmd (T a) :@ Symbolic)]
+    withoutHandle = [return $ At New]
+
+    withHandle :: [Gen (Cmd (T a) :@ Symbolic)]
+    withHandle = [
+        fmap At $ Update <$> genHandle
+      , fmap At $ Read   <$> genHandle
+      ]
+
+    genHandle :: Gen (Reference (RealHandle (T a)) Symbolic)
+    genHandle = elements (map fst hs)
+
+{-------------------------------------------------------------------------------
+  Wrapping it all up
+
+  NOTE: The parallel property will fail (intentional race condition).
+-------------------------------------------------------------------------------}
+
+ioRefTest :: StateMachineTest (T Int)
+ioRefTest = StateMachineTest {
+      initMock   = Map.empty
+    , generator  = IORefs.generator
+    , shrinker   = \_ _ -> []
+    , newHandles = toList
+    , runMock    = IORefs.runMock 0 (+1)
+    , runReal    = IORefs.runReal 0 (+1)
+    , cleanup    = \_ -> return ()
+    }
+
+prop_IORefs_sequential :: Property
+prop_IORefs_sequential = prop_sequential ioRefTest Nothing

--- a/test/RQlite.hs
+++ b/test/RQlite.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DeriveTraversable    #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE PackageImports       #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE RecordWildCards      #-}
@@ -34,8 +35,8 @@ import           Data.Maybe
 import           Data.TreeDiff
 import           GHC.Generics
 import           Prelude
-import           Rqlite
-import           Rqlite.Status
+import "hs-rqlite" Rqlite
+import "hs-rqlite" Rqlite.Status
 import           System.Directory
 import           System.IO
 import           System.Process

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,6 +27,7 @@ import           DieHard
 import           Echo
 import           ErrorEncountered
 import           Hanoi
+import           IORefs
 import           MemoryReference
 import           Mock
 import           Overflow
@@ -201,6 +202,9 @@ tests docker0 = testGroup "Tests"
       ]
   , testGroup "UnionFind"
       [ testProperty "Sequential" UnionFind.prop_unionFindSequential ]
+  , testGroup "Lockstep"
+      [ testProperty "IORefs_Sequential" prop_IORefs_sequential
+      ]
   ]
   where
     statsDb :: PropertyName -> StatsDb IO


### PR DESCRIPTION
Submitting a draft PR to let you guys know we've been working on this and made quite a bit of progress. However, I am yet to use these abstractions in my real/large QSM test setup (or indeed in the QSM tests themselves that use the patterns from my blog post), so I'm sure a bit more further tweaking will be required. However, quite pleased with how this turned out.

This is joint work with Alfredo Di Napoli.

# High-level interface to the state machine API

 This captures the patterns described in http://www.well-typed.com/blog/2019/01/qsm-in-depth/ as a proper Haskell abstraction. The basic idea is that we have a concept of commands and responses (just like in the lower level API), along with two interpretors, one for the system under test and one for the model. We then compare that they can run in lockstep, comparing responses at every step, insisting that they must be equal.
    
Of course requiring that responses must be really _equal_ is too strong: the system under test might return a real file handle for example, where the model will return a mock file handle. So we compare responses up to a mapping from real handles to mock handles, which is maintained by the Lockstep infrastructure.
    
It comes in two variants: one n-ary variant supporting an arbitrary number of different types of handles, and one where there is precisely one. The n-ary version is needed if testing for example a system that might return both DB handles and file handles, but in most cases the simple one suffices and is much easier to use. The simple API is defined in terms of the n-ary one (which requires some more sophisticated types).
    
The `IORefs` test is a nice example that demonstrates quite how succinctly we can write model tests with these abstractions.