### PR TITLE
Relax QuickCheck bound

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -66,7 +66,7 @@ library
         time >=1.7,
         pretty-show >=1.6.16,
         process >=1.2.0.0,
-        QuickCheck >=2.13.2,
+        QuickCheck >=2.12,
         random >=1.1,
         sop-core,
         split,


### PR DESCRIPTION
In 81a6c1c8376d72c570bbfc65b626e67687c36d59 and a3050887cda78e216bc4222bccbc8594528cc637, the QuickCheck bound was bumped from 2.9.2 to 2.13.1 to 2.13.2, while 2.12 is already low enough.