### PR TITLE
Rename Aux.hs to Auxiliary.hs

### DIFF
--- a/quickcheck-state-machine.cabal
+++ b/quickcheck-state-machine.cabal
@@ -34,7 +34,7 @@ library
                      , Test.StateMachine.ConstructorName
                      , Test.StateMachine.DotDrawing
                      , Test.StateMachine.Labelling
-                     , Test.StateMachine.Lockstep.Aux
+                     , Test.StateMachine.Lockstep.Auxiliary
                      , Test.StateMachine.Lockstep.NAry
                      , Test.StateMachine.Lockstep.Simple
                      , Test.StateMachine.Logic

--- a/src/Test/StateMachine/Lockstep/Auxiliary.hs
+++ b/src/Test/StateMachine/Lockstep/Auxiliary.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Test.StateMachine.Lockstep.Aux (
+module Test.StateMachine.Lockstep.Auxiliary (
     Elem(..)
   , npAt
   , NTraversable(..)

--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -60,7 +60,7 @@ import qualified Data.TreeDiff                 as TD
 import qualified Test.StateMachine.Types       as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 
-import Test.StateMachine.Lockstep.Aux
+import Test.StateMachine.Lockstep.Auxiliary
 
 {-------------------------------------------------------------------------------
   Test type-level parameters

--- a/src/Test/StateMachine/Lockstep/Simple.hs
+++ b/src/Test/StateMachine/Lockstep/Simple.hs
@@ -40,7 +40,7 @@ import Data.SOP
 import Data.Typeable
 import Test.QuickCheck
 import Test.StateMachine
-import Test.StateMachine.Lockstep.Aux
+import Test.StateMachine.Lockstep.Auxiliary
 import Test.StateMachine.Lockstep.NAry (MockState)
 
 import qualified Test.StateMachine.Lockstep.NAry as NAry


### PR DESCRIPTION
Even with an extension, the Aux filename is not allowed on Windows.