### PR TITLE
export toStateMachine from Test.StateMachine.Lockstep.NAry

### DIFF
--- a/src/Test/StateMachine/Lockstep/NAry.hs
+++ b/src/Test/StateMachine/Lockstep/NAry.hs
@@ -39,6 +39,8 @@ module Test.StateMachine.Lockstep.NAry (
     -- * Running the tests
   , prop_sequential
   , prop_parallel
+  -- * Translate to state machine model
+  , toStateMachine
   ) where
 
 import           Data.Functor.Classes


### PR DESCRIPTION
The immediate motivation for this is to get access to `forAllCommands`,
to facilitate labeling of test cases.